### PR TITLE
fix: config resolution, dark mode detection, safety, and highlight-focused config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-05-19
+
+### Fixed
+
+- Fixed Windows switcher stalls during rapid komorebi workspace and window state updates.
+- Reduced redundant taskbar enumeration and coalesced bursty komorebi notifications before updating the UI.
+
 ### Added
 
 - Added indicator colors via `[colors]` and `[monitors.<id>.colors]`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,7 +2151,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "komorebi-switcher"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "color",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,7 +2151,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "komorebi-switcher"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "color",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "komorebi-switcher"
-version = "0.10.1"
+version = "0.10.2"
 description = "A minimal workspace switcher for the Komorebi tiling window manager, seamlessly integrated into Windows 10/11 taskbar or macOS menu bar."
 authors = ["Amr Bashir <amr.bashir2015@gmail.com>"]
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "komorebi-switcher"
-version = "0.10.2"
+version = "0.10.3"
 description = "A minimal workspace switcher for the Komorebi tiling window manager, seamlessly integrated into Windows 10/11 taskbar or macOS menu bar."
 authors = ["Amr Bashir <amr.bashir2015@gmail.com>"]
 edition = "2021"

--- a/installer/Info.plist
+++ b/installer/Info.plist
@@ -11,6 +11,6 @@
         <key>CFBundleName</key>
         <string>komorebi-switcher</string>
         <key>CFBundleVersion</key>
-        <string>0.10.1</string>
+        <string>0.10.2</string>
     </dict>
 </plist>

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -15,7 +15,7 @@ RequestExecutionLevel user
 !define PRODUCTNAME "komorebi-switcher"
 !define MAINBINARYNAME "komorebi-switcher.exe"
 !define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"
-!define VERSION "0.10.2"
+!define VERSION "0.10.3"
 !define PUBLISHER "Amr Bashir"
 
 VIProductVersion "${VERSION}.0"

--- a/installer/installer.nsi
+++ b/installer/installer.nsi
@@ -15,7 +15,7 @@ RequestExecutionLevel user
 !define PRODUCTNAME "komorebi-switcher"
 !define MAINBINARYNAME "komorebi-switcher.exe"
 !define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"
-!define VERSION "0.10.1"
+!define VERSION "0.10.2"
 !define PUBLISHER "Amr Bashir"
 
 VIProductVersion "${VERSION}.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,22 @@ use std::path::PathBuf;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedMonitorConfig {
+    pub show_layout_button: bool,
+    pub hide_empty_workspaces: bool,
+    pub font_family: Option<String>,
+    pub font_weight: u16,
+    pub active_indicator: Option<String>,
+    pub busy_indicator: Option<String>,
+    pub auto_width: bool,
+    pub auto_height: bool,
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
 fn default_width() -> i32 {
     200
 }
@@ -156,7 +172,6 @@ impl Config {
         self.monitors.get(monitor_id).cloned().unwrap_or_default()
     }
 
-    #[allow(dead_code)]
     pub fn get_monitor_mut(&mut self, monitor_id: &str) -> &mut MonitorConfig {
         self.monitors.entry(monitor_id.to_string()).or_default()
     }
@@ -164,6 +179,42 @@ impl Config {
     #[allow(dead_code)]
     pub fn set_monitor(&mut self, monitor_id: &str, config: MonitorConfig) {
         self.monitors.insert(monitor_id.to_string(), config);
+    }
+
+    pub fn resolved_monitor_config(&self, monitor_id: &str) -> ResolvedMonitorConfig {
+        let mc = self.get_monitor(monitor_id);
+
+        let show_layout_button = mc.show_layout_button.unwrap_or(self.show_layout_button);
+        let hide_empty_workspaces = mc
+            .hide_empty_workspaces
+            .unwrap_or(self.hide_empty_workspaces);
+
+        let font_family = mc.font_family.or(self.font_family.clone());
+        let font_weight = mc.font_weight.or(self.font_weight).unwrap_or(400);
+
+        let active_indicator = mc
+            .colors
+            .active_indicator
+            .or(self.colors.active_indicator.clone());
+        let busy_indicator = mc
+            .colors
+            .busy_indicator
+            .or(self.colors.busy_indicator.clone());
+
+        ResolvedMonitorConfig {
+            show_layout_button,
+            hide_empty_workspaces,
+            font_family,
+            font_weight,
+            active_indicator,
+            busy_indicator,
+            auto_width: mc.auto_width,
+            auto_height: mc.auto_height,
+            x: mc.x,
+            y: mc.y,
+            width: mc.width,
+            height: mc.height,
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct ResolvedMonitorConfig {
     pub show_layout_button: bool,
     pub hide_empty_workspaces: bool,
+    pub highlight_focused_workspace: bool,
     pub font_family: Option<String>,
     pub font_weight: u16,
     pub active_indicator: Option<String>,
@@ -50,6 +51,9 @@ pub struct MonitorConfig {
     pub hide_empty_workspaces: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub highlight_focused_workspace: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<u16>,
@@ -78,6 +82,7 @@ impl Default for MonitorConfig {
         Self {
             show_layout_button: None,
             hide_empty_workspaces: None,
+            highlight_focused_workspace: None,
             font_family: None,
             font_weight: None,
             colors: ColorsConfig::default(),
@@ -97,6 +102,9 @@ pub struct Config {
     pub show_layout_button: bool,
     #[serde(default)]
     pub hide_empty_workspaces: bool,
+
+    #[serde(default = "default_true")]
+    pub highlight_focused_workspace: bool,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,
@@ -189,6 +197,10 @@ impl Config {
             .hide_empty_workspaces
             .unwrap_or(self.hide_empty_workspaces);
 
+        let highlight_focused_workspace = mc
+            .highlight_focused_workspace
+            .unwrap_or(self.highlight_focused_workspace);
+
         let font_family = mc.font_family.or(self.font_family.clone());
         let font_weight = mc.font_weight.or(self.font_weight).unwrap_or(400);
 
@@ -204,6 +216,7 @@ impl Config {
         ResolvedMonitorConfig {
             show_layout_button,
             hide_empty_workspaces,
+            highlight_focused_workspace,
             font_family,
             font_weight,
             active_indicator,

--- a/src/komorebi/client.rs
+++ b/src/komorebi/client.rs
@@ -4,6 +4,7 @@ use std::io::{BufReader, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::mpsc;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -121,6 +122,7 @@ pub enum KSocketMessage {
 #[derive(Debug, strum::Display, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum KSocketEvent {
+    AddSubscriberSocket,
     FocusWorkspaceNumber,
     FocusMonitorNumber,
     FocusMonitorWorkspaceNumber,
@@ -173,6 +175,7 @@ pub struct KNotification {
 }
 
 const KOMOREBI_SOCK: &str = "komorebi.sock";
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn komorebi_data_dir() -> anyhow::Result<Rc<PathBuf>> {
     thread_local! {
@@ -190,11 +193,28 @@ fn komorebi_data_dir() -> anyhow::Result<Rc<PathBuf>> {
     })
 }
 
+fn connect(socket: PathBuf) -> anyhow::Result<UnixStream> {
+    let (tx, rx) = mpsc::sync_channel(1);
+
+    std::thread::spawn(move || {
+        let _ = tx.send(UnixStream::connect(socket));
+    });
+
+    rx.recv_timeout(SOCKET_TIMEOUT)
+        .map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "komorebi socket connect timed out",
+            )
+        })?
+        .map_err(Into::into)
+}
+
 pub fn send_message(message: &KSocketMessage) -> anyhow::Result<()> {
     let socket = komorebi_data_dir()?.join(KOMOREBI_SOCK);
 
-    let mut stream = UnixStream::connect(socket)?;
-    stream.set_write_timeout(Some(Duration::from_secs(1)))?;
+    let mut stream = connect(socket)?;
+    stream.set_write_timeout(Some(SOCKET_TIMEOUT))?;
     stream.write_all(serde_json::to_string(message)?.as_bytes())?;
 
     Ok(())
@@ -203,9 +223,9 @@ pub fn send_message(message: &KSocketMessage) -> anyhow::Result<()> {
 pub fn send_query(message: KSocketMessage) -> anyhow::Result<String> {
     let socket = komorebi_data_dir()?.join(KOMOREBI_SOCK);
 
-    let mut stream = UnixStream::connect(socket)?;
-    stream.set_read_timeout(Some(Duration::from_secs(1)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(1)))?;
+    let mut stream = connect(socket)?;
+    stream.set_read_timeout(Some(SOCKET_TIMEOUT))?;
+    stream.set_write_timeout(Some(SOCKET_TIMEOUT))?;
     stream.write_all(serde_json::to_string(&message)?.as_bytes())?;
     stream.shutdown(std::net::Shutdown::Write)?;
 

--- a/src/komorebi/mod.rs
+++ b/src/komorebi/mod.rs
@@ -1,4 +1,5 @@
 use std::io::{BufReader, Read};
+use std::sync::mpsc;
 use std::time::Duration;
 
 use client::*;
@@ -7,7 +8,7 @@ pub use crate::komorebi::client::KCycleDirection as CycleDirection;
 
 mod client;
 
-#[derive(Debug, Clone, Default, Copy)]
+#[derive(Debug, Clone, Default, Copy, PartialEq, Eq)]
 #[allow(unused)]
 pub struct Rect {
     pub left: i32,
@@ -40,7 +41,7 @@ impl Rect {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Workspace {
     pub name: String,
     pub index: usize,
@@ -49,7 +50,7 @@ pub struct Workspace {
     pub layout: String,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[allow(unused)]
 pub struct Monitor {
     pub name: String,
@@ -106,9 +107,32 @@ impl Monitor {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct State {
     pub monitors: Vec<Monitor>,
+}
+
+impl State {
+    fn focused_workspaces_summary(&self) -> String {
+        self.monitors
+            .iter()
+            .map(|monitor| {
+                let monitor_name = if monitor.name.is_empty() {
+                    monitor.id.as_str()
+                } else {
+                    monitor.name.as_str()
+                };
+
+                let workspace = monitor
+                    .focused_workspace()
+                    .map(|workspace| workspace.name.as_str())
+                    .unwrap_or("<none>");
+
+                format!("{monitor_name}:{workspace}")
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 }
 
 impl From<KState> for State {
@@ -137,18 +161,22 @@ pub fn change_workspace(monitor_idx: usize, workspace_idx: usize) {
     tracing::info!("Changing komorebi workspace to {workspace_idx} on monitor {monitor_idx}");
 
     let change_msg = KSocketMessage::FocusMonitorWorkspaceNumber(monitor_idx, workspace_idx);
-    if let Err(e) = client::send_message(&change_msg) {
-        tracing::error!("Failed to change workspace: {e}")
-    }
+    send_message_async(change_msg, "change workspace");
 }
 
 pub fn cycle_layout(direction: CycleDirection) {
     tracing::info!("Changing to {direction} komorebi layout");
 
     let change_msg = KSocketMessage::CycleLayout(direction);
-    if let Err(e) = client::send_message(&change_msg) {
-        tracing::error!("Failed to change layout: {e}")
-    }
+    send_message_async(change_msg, "cycle layout");
+}
+
+fn send_message_async(message: KSocketMessage, action: &'static str) {
+    std::thread::spawn(move || {
+        if let Err(e) = client::send_message(&message) {
+            tracing::error!("Failed to {action}: {e}");
+        }
+    });
 }
 
 #[cfg(debug_assertions)]
@@ -157,6 +185,47 @@ const SOCK_NAME: &str = "komorebi-switcher-debug.sock";
 const SOCK_NAME: &str = "komorebi-switcher.sock";
 
 pub fn listen_for_state(on_new_state: impl Fn(State) + Send + 'static) {
+    let (state_tx, state_rx) = mpsc::channel::<(String, State)>();
+    std::thread::spawn(move || {
+        let mut last_state = None;
+
+        while let Ok((mut event, mut state)) = state_rx.recv() {
+            let mut event_count = 1;
+
+            while let Ok((next_event, next_state)) =
+                state_rx.recv_timeout(Duration::from_millis(50))
+            {
+                event = next_event;
+                state = next_state;
+                event_count += 1;
+            }
+
+            if event == "AddSubscriberSocket" && last_state.is_none() {
+                tracing::debug!(
+                    "Initialized komorebi subscription state, focused: {}",
+                    state.focused_workspaces_summary()
+                );
+                last_state = Some(state);
+                continue;
+            }
+
+            if last_state.as_ref() == Some(&state) {
+                tracing::debug!(
+                    "Ignoring unchanged komorebi state after {event_count} event(s), last event: {event}"
+                );
+                continue;
+            }
+
+            tracing::debug!(
+                "Applying komorebi state update after {event_count} event(s), last event: {event}, focused: {}",
+                state.focused_workspaces_summary()
+            );
+
+            last_state = Some(state.clone());
+            on_new_state(state);
+        }
+    });
+
     let socket = loop {
         match client::subscribe(SOCK_NAME) {
             Ok(socket) => break socket,
@@ -209,15 +278,15 @@ pub fn listen_for_state(on_new_state: impl Fn(State) + Send + 'static) {
 
         tracing::trace!("Received komorebi message: {value}");
 
-        tracing::debug!(
-            "Received an event from komorebi: {}",
-            value
-                .get("event")
-                .and_then(|o| o.as_object())
-                .and_then(|o| o.get("type"))
-                .map(|v| v.to_string())
-                .unwrap_or_default()
-        );
+        let event = value
+            .get("event")
+            .and_then(|o| o.as_object())
+            .and_then(|o| o.get("type"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("<unknown>")
+            .to_string();
+
+        tracing::trace!("Received an event from komorebi: {event}");
 
         let notification = match serde_json::from_value::<KNotification>(value) {
             Ok(notification) => notification,
@@ -227,6 +296,8 @@ pub fn listen_for_state(on_new_state: impl Fn(State) + Send + 'static) {
             }
         };
 
-        on_new_state(notification.state.into());
+        if let Err(e) = state_tx.send((event, State::from(notification.state))) {
+            tracing::error!("Failed to queue komorebi state update: {e}");
+        }
     }
 }

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -166,6 +166,7 @@ impl AppDelegate {
                 custom_font,
                 resolved.active_indicator.as_deref(),
                 resolved.busy_indicator.as_deref(),
+                resolved.highlight_focused_workspace,
             );
             stack_view.addArrangedSubview(&workspace_button);
             views.push(workspace_button.downcast().unwrap());

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -16,7 +16,7 @@ use objc2_foundation::{
 
 use self::workspace_button::WorkspaceButton;
 use self::workspaces_stack_view::WorkspacesStackView;
-use crate::config::Config;
+use crate::config::{Config, ResolvedMonitorConfig};
 use crate::macos::layout_button::LayoutButton;
 use crate::macos::windows::settings::SettingsWindowController;
 
@@ -84,10 +84,11 @@ define_class!(
             let config = Config::load().unwrap_or_default();
 
             // Resolve custom font lazily once at startup.
-            let custom_font = config.font_family.as_deref().and_then(|family| {
-                let weight = config.font_weight.unwrap_or(400);
+            let resolved = config.resolved_monitor_config("");
+            let custom_font = resolved.font_family.as_deref().and_then(|family| {
                 let size = NSFont::systemFontOfSize(0.0).pointSize();
-                let postscript_name = crate::utils::find_font(family, weight)?.postscript_name()?;
+                let postscript_name =
+                    crate::utils::find_font(family, resolved.font_weight)?.postscript_name()?;
                 NSFont::fontWithName_size(&NSString::from_str(&postscript_name), size)
             });
             let _ = self.ivars().custom_font.set(custom_font);
@@ -139,6 +140,7 @@ impl AppDelegate {
         let stack_view = self.ivars().ns_stack_view.get().unwrap();
         let mut views = self.ivars().buttons.borrow_mut();
         let config = self.ivars().config.get().unwrap();
+        let resolved = config.resolved_monitor_config("");
 
         for button in views.iter() {
             button.removeFromSuperview();
@@ -152,11 +154,9 @@ impl AppDelegate {
 
         // Use the cached resolved custom font
         let custom_font = self.ivars().custom_font.get().and_then(|f| f.as_deref());
-        let active_indicator_color = config.colors.active_indicator.as_deref();
-        let busy_indicator_color = config.colors.busy_indicator.as_deref();
 
         for workspace in &monitor.workspaces {
-            if config.hide_empty_workspaces && workspace.is_empty && !workspace.focused {
+            if resolved.hide_empty_workspaces && workspace.is_empty && !workspace.focused {
                 continue;
             }
 
@@ -164,14 +164,14 @@ impl AppDelegate {
                 mtm,
                 workspace,
                 custom_font,
-                active_indicator_color,
-                busy_indicator_color,
+                resolved.active_indicator.as_deref(),
+                resolved.busy_indicator.as_deref(),
             );
             stack_view.addArrangedSubview(&workspace_button);
             views.push(workspace_button.downcast().unwrap());
         }
 
-        if config.show_layout_button {
+        if resolved.show_layout_button {
             if let Some(focused_ws) = monitor.focused_workspace() {
                 let separator = NSTextField::labelWithString(ns_string!("|"), mtm);
                 separator.setAlignment(NSTextAlignment::Center);

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -16,7 +16,7 @@ use objc2_foundation::{
 
 use self::workspace_button::WorkspaceButton;
 use self::workspaces_stack_view::WorkspacesStackView;
-use crate::config::{Config, ResolvedMonitorConfig};
+use crate::config::Config;
 use crate::macos::layout_button::LayoutButton;
 use crate::macos::windows::settings::SettingsWindowController;
 

--- a/src/macos/workspace_button.rs
+++ b/src/macos/workspace_button.rs
@@ -100,6 +100,7 @@ impl WorkspaceButton {
         font: Option<&NSFont>,
         active_indicator_color: Option<&str>,
         busy_indicator_color: Option<&str>,
+        highlight_focused: bool,
     ) -> Retained<Self> {
         // Create button
         let this = Self::alloc(mtm).set_ivars(WorkspaceButtonIvars::new(workspace.clone()));
@@ -134,7 +135,7 @@ impl WorkspaceButton {
         height_constraint.setActive(true);
 
         // Set background color based on active state
-        let bg_color = if workspace.focused {
+        let bg_color = if highlight_focused && workspace.focused {
             NSColor::colorWithWhite_alpha(1.0, 0.1).CGColor()
         } else {
             NSColor::clearColor().CGColor()

--- a/src/windows/app.rs
+++ b/src/windows/app.rs
@@ -219,20 +219,25 @@ impl ApplicationHandler<AppMessage> for App {
         window_id: WindowId,
         event: WindowEvent,
     ) {
-        if event == WindowEvent::Destroyed {
-            tracing::info!("Window {window_id:?} destroyed");
-            self.windows.remove(&window_id);
-            return;
-        }
+        match event {
+            WindowEvent::CloseRequested => {
+                tracing::info!("Window {window_id:?} close requested");
+                self.windows.remove(&window_id);
 
-        if matches!(event, WindowEvent::CloseRequested | WindowEvent::Destroyed) {
-            tracing::info!("Closing window {window_id:?}");
-            self.windows.remove(&window_id);
-
-            if self.windows.is_empty() {
-                tracing::info!("Exiting event loop");
-                event_loop.exit();
+                if self.windows.is_empty() {
+                    tracing::info!("Exiting event loop");
+                    event_loop.exit();
+                }
+                return;
             }
+
+            WindowEvent::Destroyed => {
+                tracing::info!("Window {window_id:?} destroyed");
+                self.windows.remove(&window_id);
+                return;
+            }
+
+            _ => {}
         }
 
         let Some(window) = self.windows.get_mut(&window_id) else {

--- a/src/windows/app.rs
+++ b/src/windows/app.rs
@@ -81,16 +81,24 @@ impl App {
     }
 
     fn create_switchers(&mut self, event_loop: &ActiveEventLoop) -> anyhow::Result<()> {
+        let missing_monitors = self
+            .komorebi_state
+            .monitors
+            .clone()
+            .into_iter()
+            .filter(|monitor| !self.windows.contains_key_alt(&Some(monitor.id.clone())))
+            .collect::<Vec<_>>();
+
+        if missing_monitors.is_empty() {
+            return Ok(());
+        }
+
         let taskbars = crate::windows::taskbar::all();
 
         tracing::debug!("Found {} taskbars: {taskbars:?}", taskbars.len());
 
-        for monitor in self.komorebi_state.monitors.clone().into_iter() {
-            // skip already existing window for this monitor
+        for monitor in missing_monitors {
             let monitor_id = monitor.id.clone();
-            if self.windows.contains_key_alt(&Some(monitor_id.clone())) {
-                continue;
-            }
 
             let Some(taskbar) = taskbars.iter().find(|tb| monitor.rect.contains(tb.rect)) else {
                 tracing::warn!(

--- a/src/windows/egui_glue/egui_renderer.rs
+++ b/src/windows/egui_glue/egui_renderer.rs
@@ -68,8 +68,14 @@ impl EguiRenderer {
         window_surface_view: &wgpu::TextureView,
         screen_descriptor: egui_wgpu::ScreenDescriptor,
     ) {
+        debug_assert!(
+            self.frame_started,
+            "begin_frame must be called before end_frame_and_draw can be called!"
+        );
+
         if !self.frame_started {
-            panic!("begin_frame must be called before end_frame_and_draw can be called!");
+            tracing::error!("end_frame_and_draw called without begin_frame");
+            return;
         }
 
         let full_output = self.state.egui_ctx().end_pass();

--- a/src/windows/message_window.rs
+++ b/src/windows/message_window.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use windows::core::*;
 use windows::Win32::Foundation::*;
@@ -16,6 +16,8 @@ const MESSAGE_WINDOW_CLASSNAME: PCWSTR = w!("komorebi-switcher::message-window")
 static WM_TASKBARCREATED: LazyLock<u32> =
     LazyLock::new(|| unsafe { RegisterWindowMessageA(s!("TaskbarCreated")) });
 
+static MESSAGE_CLASS_REGISTERED: OnceLock<()> = OnceLock::new();
+
 struct WndProcUserData {
     proxy: EventLoopProxy<AppMessage>,
 }
@@ -29,14 +31,20 @@ impl WndProcUserData {
 pub unsafe fn create(proxy: EventLoopProxy<AppMessage>) -> anyhow::Result<HWND> {
     let hinstance = GetModuleHandleW(None)?;
 
-    let wc = WNDCLASSW {
-        hInstance: hinstance.into(),
-        lpszClassName: MESSAGE_WINDOW_CLASSNAME,
-        lpfnWndProc: Some(wndproc_message_window),
-        ..Default::default()
-    };
+    MESSAGE_CLASS_REGISTERED.get_or_init(|| {
+        let wc = WNDCLASSW {
+            hInstance: hinstance.into(),
+            lpszClassName: MESSAGE_WINDOW_CLASSNAME,
+            lpfnWndProc: Some(wndproc_message_window),
+            ..Default::default()
+        };
 
-    RegisterClassW(&wc);
+        assert_ne!(
+            unsafe { RegisterClassW(&wc) },
+            0,
+            "Failed to register message window class"
+        );
+    });
 
     let userdata = WndProcUserData { proxy };
 

--- a/src/windows/widgets/workspace_button.rs
+++ b/src/windows/widgets/workspace_button.rs
@@ -80,7 +80,7 @@ impl egui::Widget for WorkspaceButton<'_> {
         let painter = ui.painter();
 
         // draw background
-        if response.hovered() || self.workspace.focused {
+        if response.hovered() {
             let color = if dark_mode {
                 egui::Color32::from_rgba_unmultiplied(255, 255, 255, 1)
             } else {

--- a/src/windows/widgets/workspace_button.rs
+++ b/src/windows/widgets/workspace_button.rs
@@ -7,6 +7,7 @@ pub struct WorkspaceButton<'a> {
     line_busy_color: Option<egui::Color32>,
     width: Option<f32>,
     dark_mode: Option<bool>,
+    highlight_focused: Option<bool>,
 }
 
 impl<'a> WorkspaceButton<'a> {
@@ -18,6 +19,7 @@ impl<'a> WorkspaceButton<'a> {
             line_busy_color: None,
             width: None,
             dark_mode: None,
+            highlight_focused: None,
         }
     }
 
@@ -43,6 +45,11 @@ impl<'a> WorkspaceButton<'a> {
 
     pub fn width_opt(mut self, width: Option<f32>) -> Self {
         self.width = width;
+        self
+    }
+
+    pub fn highlight_focused_opt(mut self, highlight_focused: Option<bool>) -> Self {
+        self.highlight_focused = highlight_focused;
         self
     }
 }
@@ -80,7 +87,8 @@ impl egui::Widget for WorkspaceButton<'_> {
         let painter = ui.painter();
 
         // draw background
-        if response.hovered() {
+        let highlight_focused = self.highlight_focused.unwrap_or(true);
+        if response.hovered() || (highlight_focused && self.workspace.focused) {
             let color = if dark_mode {
                 egui::Color32::from_rgba_unmultiplied(255, 255, 255, 1)
             } else {

--- a/src/windows/widgets/workspace_button.rs
+++ b/src/windows/widgets/workspace_button.rs
@@ -5,6 +5,7 @@ pub struct WorkspaceButton<'a> {
     text_color: Option<egui::Color32>,
     line_active_color: Option<egui::Color32>,
     line_busy_color: Option<egui::Color32>,
+    width: Option<f32>,
     dark_mode: Option<bool>,
 }
 
@@ -15,6 +16,7 @@ impl<'a> WorkspaceButton<'a> {
             text_color: None,
             line_active_color: None,
             line_busy_color: None,
+            width: None,
             dark_mode: None,
         }
     }
@@ -36,6 +38,11 @@ impl<'a> WorkspaceButton<'a> {
 
     pub fn line_busy_color_opt(mut self, color: Option<egui::Color32>) -> Self {
         self.line_busy_color = color;
+        self
+    }
+
+    pub fn width_opt(mut self, width: Option<f32>) -> Self {
+        self.width = width;
         self
     }
 }
@@ -63,7 +70,10 @@ impl egui::Widget for WorkspaceButton<'_> {
             .painter()
             .layout_no_wrap(text, font_id.clone(), text_color);
 
-        let size = MIN_SIZE.max(text_galley.rect.size() + TEXT_PADDING);
+        let mut size = MIN_SIZE.max(text_galley.rect.size() + TEXT_PADDING);
+        if let Some(width) = self.width {
+            size.x = size.x.max(width);
+        }
 
         let (rect, response) = ui.allocate_at_least(size, egui::Sense::CLICK | egui::Sense::HOVER);
 

--- a/src/windows/windows/settings.rs
+++ b/src/windows/windows/settings.rs
@@ -92,6 +92,13 @@ impl SettingsWindowView {
         ));
     }
 
+    fn global_highlight_focused_workspace_ui(&mut self, ui: &mut egui::Ui) {
+        ui.add(egui::Checkbox::new(
+            &mut self.config.highlight_focused_workspace,
+            "Highlight focused workspace",
+        ));
+    }
+
     fn global_font_family_ui(&mut self, ui: &mut egui::Ui) {
         ui.label("Font Family");
 
@@ -153,6 +160,9 @@ impl SettingsWindowView {
                 ui.end_row();
 
                 self.global_hide_empty_workspaces_ui(ui);
+                ui.end_row();
+
+                self.global_highlight_focused_workspace_ui(ui);
                 ui.end_row();
 
                 self.global_font_family_ui(ui);
@@ -252,6 +262,31 @@ impl SettingsWindowView {
 
         if before != selected {
             monitor_config.hide_empty_workspaces = selected.into();
+        }
+    }
+
+    fn highlight_focused_workspace_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
+        let monitor_config = self.config.get_monitor_mut(monitor_id);
+
+        ui.label("Highlight focused workspace");
+
+        let mut selected: ActivationOption = monitor_config.highlight_focused_workspace.into();
+        let before = selected;
+
+        egui::ComboBox::new("highlight_focused_workspace", "")
+            .selected_text(format!("{}", selected))
+            .show_ui(ui, |ui| {
+                for option in [
+                    ActivationOption::Inherit,
+                    ActivationOption::Enable,
+                    ActivationOption::Disable,
+                ] {
+                    ui.selectable_value(&mut selected, option, format!("{}", option));
+                }
+            });
+
+        if before != selected {
+            monitor_config.highlight_focused_workspace = selected.into();
         }
     }
 
@@ -356,6 +391,9 @@ impl SettingsWindowView {
         ui.end_row();
 
         self.hide_empty_workspaces_ui(ui, monitor_id);
+        ui.end_row();
+
+        self.highlight_focused_workspace_ui(ui, monitor_id);
         ui.end_row();
 
         self.font_family_ui(ui, monitor_id);

--- a/src/windows/windows/switcher/host.rs
+++ b/src/windows/windows/switcher/host.rs
@@ -33,7 +33,11 @@ pub unsafe fn create_host(
             ..Default::default()
         };
 
-        assert_ne!(unsafe { RegisterClassW(&wc) }, 0, "Failed to register host window class");
+        assert_ne!(
+            unsafe { RegisterClassW(&wc) },
+            0,
+            "Failed to register host window class"
+        );
     });
 
     let userdata = WndProcUserData { proxy };

--- a/src/windows/windows/switcher/host.rs
+++ b/src/windows/windows/switcher/host.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use windows::core::*;
 use windows::Win32::Foundation::*;
 use windows::Win32::System::LibraryLoader::*;
@@ -13,6 +15,8 @@ const HOST_CLASSNAME: PCWSTR = w!("komorebi-switcher-debug::host");
 #[cfg(not(debug_assertions))]
 const HOST_CLASSNAME: PCWSTR = w!("komorebi-switcher::host");
 
+static HOST_CLASS_REGISTERED: OnceLock<()> = OnceLock::new();
+
 pub unsafe fn create_host(
     taskbar_hwnd: HWND,
     proxy: EventLoopProxy<AppMessage>,
@@ -20,20 +24,22 @@ pub unsafe fn create_host(
 ) -> anyhow::Result<HWND> {
     let hinstance = unsafe { GetModuleHandleW(None) }?;
 
-    let mut rect = RECT::default();
-    GetClientRect(taskbar_hwnd, &mut rect)?;
+    HOST_CLASS_REGISTERED.get_or_init(|| {
+        let wc = WNDCLASSW {
+            hInstance: hinstance.into(),
+            lpszClassName: HOST_CLASSNAME,
+            style: CS_HREDRAW | CS_VREDRAW,
+            lpfnWndProc: Some(wndproc_host),
+            ..Default::default()
+        };
 
-    let wc = WNDCLASSW {
-        hInstance: hinstance.into(),
-        lpszClassName: HOST_CLASSNAME,
-        style: CS_HREDRAW | CS_VREDRAW,
-        lpfnWndProc: Some(wndproc_host),
-        ..Default::default()
-    };
-
-    RegisterClassW(&wc);
+        assert_ne!(unsafe { RegisterClassW(&wc) }, 0, "Failed to register host window class");
+    });
 
     let userdata = WndProcUserData { proxy };
+
+    let mut rect = RECT::default();
+    GetClientRect(taskbar_hwnd, &mut rect)?;
 
     let height = if monitor_config.auto_height {
         rect.bottom - rect.top

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -357,6 +357,7 @@ impl SwitcherWindowView {
             .line_active_color_opt(active_indicator_color)
             .line_busy_color_opt(busy_indicator_color)
             .width_opt(uniform_width)
+            .highlight_focused_opt(Some(resolved.highlight_focused_workspace))
             .text_color_opt(self.forgreound_color);
 
         if ui.add(btn).clicked() {

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -393,7 +393,9 @@ impl SwitcherWindowView {
             .monitor_state
             .workspaces
             .iter()
-            .filter(|workspace| !(hide_empty_workspaces && workspace.is_empty && !workspace.focused))
+            .filter(|workspace| {
+                !(hide_empty_workspaces && workspace.is_empty && !workspace.focused)
+            })
             .collect::<Vec<_>>();
 
         let uniform_width = {

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -335,6 +335,7 @@ impl SwitcherWindowView {
         workspace: &crate::komorebi::Workspace,
         monitor_config: &crate::config::MonitorConfig,
         config: &Config,
+        uniform_width: Option<f32>,
     ) {
         // Determine active indicator colors,
         // with monitor config taking precedence over global config,
@@ -364,6 +365,7 @@ impl SwitcherWindowView {
             .dark_mode(Some(self.is_system_dark_mode()))
             .line_active_color_opt(active_indicator_color)
             .line_busy_color_opt(busy_indicator_color)
+            .width_opt(uniform_width)
             .text_color_opt(self.forgreound_color);
 
         if ui.add(btn).clicked() {
@@ -387,14 +389,37 @@ impl SwitcherWindowView {
             None => config.hide_empty_workspaces,
         };
 
-        // Draw a button for each workspace
-        for workspace in self.monitor_state.workspaces.iter() {
-            //Skip empty and unfocused workspaces if the setting is enabled
-            if hide_empty_workspaces && workspace.is_empty && !workspace.focused {
-                continue;
-            }
+        let visible_workspaces = self
+            .monitor_state
+            .workspaces
+            .iter()
+            .filter(|workspace| !(hide_empty_workspaces && workspace.is_empty && !workspace.focused))
+            .collect::<Vec<_>>();
 
-            self.workspace_button(ui, workspace, monitor_config, config);
+        let uniform_width = {
+            const MIN_WIDTH: f32 = 28.0;
+            const HORIZONTAL_TEXT_PADDING: f32 = 16.0;
+
+            let max_text_width = visible_workspaces
+                .iter()
+                .map(|workspace| {
+                    ui.painter()
+                        .layout_no_wrap(
+                            workspace.name.clone(),
+                            egui::FontId::default(),
+                            egui::Color32::TRANSPARENT,
+                        )
+                        .rect
+                        .width()
+                })
+                .fold(0.0, f32::max);
+
+            Some((max_text_width + HORIZONTAL_TEXT_PADDING).max(MIN_WIDTH))
+        };
+
+        // Draw a button for each workspace
+        for workspace in visible_workspaces {
+            self.workspace_button(ui, workspace, monitor_config, config, uniform_width);
         }
 
         // Show layout button for focused workspace if the setting is enabled

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -12,7 +12,7 @@ use winit::event_loop::ActiveEventLoop;
 use winit::platform::windows::WindowAttributesExtWindows;
 use winit::window::WindowAttributes;
 
-use crate::config::Config;
+use crate::config::{Config, ResolvedMonitorConfig};
 use crate::komorebi::CycleDirection;
 use crate::windows::app::{App, AppMessage};
 use crate::windows::context_menu::AppContextMenu;
@@ -51,7 +51,10 @@ impl App {
             monitor_config.height,
         ));
 
-        let parent = unsafe { NonZero::new_unchecked(host.0 as _) };
+        let parent = {
+            debug_assert!(!host.is_invalid(), "host window must not be null");
+            unsafe { NonZero::new_unchecked(host.0 as _) }
+        };
         let parent = Win32WindowHandle::new(parent);
         let parent = RawWindowHandle::Win32(parent);
         attrs = unsafe { attrs.with_parent_window(Some(parent)) };
@@ -95,6 +98,7 @@ pub struct SwitcherWindowView {
     accent_light2_color: Option<egui::Color32>,
     accent_color: Option<egui::Color32>,
     forgreound_color: Option<egui::Color32>,
+    dark_mode: Option<bool>,
     prev_bounds: Option<egui::Rect>,
     applied_font: Option<(String, u16)>,
 }
@@ -115,6 +119,7 @@ impl SwitcherWindowView {
             accent_color: None,
             accent_light2_color: None,
             forgreound_color: None,
+            dark_mode: None,
             config,
             preview_config: None,
             prev_bounds: None,
@@ -132,13 +137,15 @@ impl SwitcherWindowView {
 
 /// Getters
 impl SwitcherWindowView {
-    /// Gets the effective config for the switcher, which is the preview config
-    /// if set, or the actual config otherwise.
-    fn effective_config(&self) -> Config {
-        self.preview_config.clone().unwrap_or_else(|| {
-            let config = self.config.read().unwrap();
-            config.clone()
-        })
+    fn resolved_config(&self) -> ResolvedMonitorConfig {
+        if let Some(preview) = &self.preview_config {
+            preview.resolved_monitor_config(&self.monitor_state.id)
+        } else {
+            self.config
+                .read()
+                .unwrap()
+                .resolved_monitor_config(&self.monitor_state.id)
+        }
     }
 
     /// Gets the height of the taskbar.
@@ -150,11 +157,8 @@ impl SwitcherWindowView {
     }
 
     /// Determines if the system is in dark mode.
-    // FIXME: use egui internal dark mode detection
     fn is_system_dark_mode(&self) -> bool {
-        self.forgreound_color
-            .map(|c| c == egui::Color32::WHITE)
-            .unwrap_or(false)
+        self.dark_mode.unwrap_or(false)
     }
 
     /// Gets the accent color to use for the switcher, based on the system
@@ -196,6 +200,14 @@ impl SwitcherWindowView {
         let color = egui::Color32::from_rgb(color.R, color.G, color.B);
         self.forgreound_color.replace(color);
 
+        let dark_mode = windows_registry::CURRENT_USER
+            .open("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize")
+            .ok()
+            .and_then(|key| key.get_u32("AppsUseLightTheme").ok())
+            .map(|v| v == 0)
+            .unwrap_or(false);
+        self.dark_mode.replace(dark_mode);
+
         Ok(())
     }
 
@@ -205,24 +217,24 @@ impl SwitcherWindowView {
         &mut self,
         rect: egui::Rect,
         ppp: f32,
-        monitor_config: &crate::config::MonitorConfig,
+        resolved: &ResolvedMonitorConfig,
     ) -> anyhow::Result<()> {
         // Scale by pixels per point
         let rect = rect * ppp;
 
-        let x = monitor_config.x;
-        let y = monitor_config.y;
+        let x = resolved.x;
+        let y = resolved.y;
 
-        let height = if monitor_config.auto_height {
+        let height = if resolved.auto_height {
             self.taskbar_height()?
         } else {
-            monitor_config.height
+            resolved.height
         };
 
-        let width = if monitor_config.auto_width {
+        let width = if resolved.auto_width {
             rect.width() as i32
         } else {
-            monitor_config.width
+            resolved.width
         };
 
         let current_bounds = egui::Rect::from_min_size(
@@ -247,7 +259,7 @@ impl SwitcherWindowView {
             }?;
 
             // Store auto size if needed
-            if monitor_config.auto_width || monitor_config.auto_height {
+            if resolved.auto_width || resolved.auto_height {
                 let _ = registry::store_auto_size(&self.monitor_state.id, width, height);
             }
 
@@ -263,17 +275,10 @@ impl SwitcherWindowView {
     fn maybe_apply_font(
         &mut self,
         ctx: &egui::Context,
-        config: &Config,
-        monitor_config: &crate::config::MonitorConfig,
+        resolved: &ResolvedMonitorConfig,
     ) {
-        let font_family = monitor_config
-            .font_family
-            .as_deref()
-            .or(config.font_family.as_deref());
-        let font_weight = monitor_config
-            .font_weight
-            .or(config.font_weight)
-            .unwrap_or(400);
+        let font_family = resolved.font_family.as_deref();
+        let font_weight = resolved.font_weight;
 
         // Skip if the desired font is already applied
         let desired = font_family.map(|family| (family.to_string(), font_weight));
@@ -333,33 +338,19 @@ impl SwitcherWindowView {
         &self,
         ui: &mut egui::Ui,
         workspace: &crate::komorebi::Workspace,
-        monitor_config: &crate::config::MonitorConfig,
-        config: &Config,
+        resolved: &ResolvedMonitorConfig,
         uniform_width: Option<f32>,
     ) {
-        // Determine active indicator colors,
-        // with monitor config taking precedence over global config,
-        // and falling back to accent color if not specified.
-        let active_indicator_color = match monitor_config.colors.active_indicator {
-            Some(ref c) => egui_color_from_color(c),
-            None => config
-                .colors
-                .active_indicator
-                .as_ref()
-                .and_then(|c| egui_color_from_color(c)),
-        };
-        let active_indicator_color = active_indicator_color.or_else(|| self.accent_color());
+        let active_indicator_color = resolved
+            .active_indicator
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c))
+            .or_else(|| self.accent_color());
 
-        // Determine busy indicator color,
-        // with monitor config taking precedence over global config.
-        let busy_indicator_color = match monitor_config.colors.busy_indicator {
-            Some(ref c) => egui_color_from_color(c),
-            None => config
-                .colors
-                .busy_indicator
-                .as_ref()
-                .and_then(|c| egui_color_from_color(c)),
-        };
+        let busy_indicator_color = resolved
+            .busy_indicator
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c));
 
         let btn = WorkspaceButton::new(workspace)
             .dark_mode(Some(self.is_system_dark_mode()))
@@ -377,17 +368,11 @@ impl SwitcherWindowView {
     fn switcher_ui(
         &mut self,
         ui: &mut egui::Ui,
-        config: &Config,
-        monitor_config: &crate::config::MonitorConfig,
+        resolved: &ResolvedMonitorConfig,
     ) {
-        // Set spacing between buttons
         ui.style_mut().spacing.item_spacing = egui::vec2(4., 4.);
 
-        // Determine whether to show or hide empty workspaces
-        let hide_empty_workspaces = match monitor_config.hide_empty_workspaces {
-            Some(hide) => hide,
-            None => config.hide_empty_workspaces,
-        };
+        let hide_empty_workspaces = resolved.hide_empty_workspaces;
 
         let visible_workspaces = self
             .monitor_state
@@ -421,14 +406,10 @@ impl SwitcherWindowView {
 
         // Draw a button for each workspace
         for workspace in visible_workspaces {
-            self.workspace_button(ui, workspace, monitor_config, config, uniform_width);
+            self.workspace_button(ui, workspace, resolved, uniform_width);
         }
 
-        // Show layout button for focused workspace if the setting is enabled
-        let show_layout_button = match monitor_config.show_layout_button {
-            Some(show) => show,
-            None => config.show_layout_button,
-        };
+        let show_layout_button = resolved.show_layout_button;
         if show_layout_button {
             if let Some(focused_ws) = self.monitor_state.focused_workspace() {
                 ui.add(egui::Label::new("|"));
@@ -443,8 +424,7 @@ impl SwitcherWindowView {
     fn switcher_panel(
         &mut self,
         ctx: &egui::Context,
-        config: &Config,
-        monitor_config: &crate::config::MonitorConfig,
+        resolved: &ResolvedMonitorConfig,
     ) -> egui::InnerResponse<egui::Rect> {
         // Set transparent panel visual for the switcher.
         let visuals = egui::Visuals {
@@ -460,7 +440,7 @@ impl SwitcherWindowView {
         let total_margin = frame.total_margin();
         egui::CentralPanel::default().frame(frame).show(ctx, |ui| {
             let response = ui.horizontal_centered(|ui| {
-                self.switcher_ui(ui, config, monitor_config);
+                self.switcher_ui(ui, resolved);
                 ui.min_rect()
             });
 
@@ -507,24 +487,18 @@ impl EguiView for SwitcherWindowView {
 
     // Main render loop
     fn update(&mut self, ctx: &egui::Context) {
-        // Show context menu on right click
         if ctx.input(|i| i.pointer.button_pressed(egui::PointerButton::Secondary)) {
             self.show_context_menu();
         }
 
-        // Load effective config.
-        let config = self.effective_config();
-        let monitor_config = config.get_monitor(&self.monitor_state.id);
+        let resolved = self.resolved_config();
 
-        // Apply font
-        self.maybe_apply_font(ctx, &config, &monitor_config);
+        self.maybe_apply_font(ctx, &resolved);
 
-        // Draw ui
-        let response = self.switcher_panel(ctx, &config, &monitor_config);
+        let response = self.switcher_panel(ctx, &resolved);
 
-        // Resize host to match the content rect.
         let ppp = ctx.pixels_per_point();
-        if let Err(e) = self.resize_host_to_rect(response.inner, ppp, &monitor_config) {
+        if let Err(e) = self.resize_host_to_rect(response.inner, ppp, &resolved) {
             tracing::error!("Failed to resize host to rect: {e}");
         }
     }

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -272,11 +272,7 @@ impl SwitcherWindowView {
 
     /// Applies the desired font to the egui context if it's not already
     /// applied.
-    fn maybe_apply_font(
-        &mut self,
-        ctx: &egui::Context,
-        resolved: &ResolvedMonitorConfig,
-    ) {
+    fn maybe_apply_font(&mut self, ctx: &egui::Context, resolved: &ResolvedMonitorConfig) {
         let font_family = resolved.font_family.as_deref();
         let font_weight = resolved.font_weight;
 
@@ -366,11 +362,7 @@ impl SwitcherWindowView {
     }
 
     /// Main UI elements, workspaces buttons, layout button ...etc
-    fn switcher_ui(
-        &mut self,
-        ui: &mut egui::Ui,
-        resolved: &ResolvedMonitorConfig,
-    ) {
+    fn switcher_ui(&mut self, ui: &mut egui::Ui, resolved: &ResolvedMonitorConfig) {
         ui.style_mut().spacing.item_spacing = egui::vec2(4., 4.);
 
         let hide_empty_workspaces = resolved.hide_empty_workspaces;


### PR DESCRIPTION
## Commits

### Fix komorebi state update stalls (e69722e)
- Socket connect with 1s timeout (was blocked indefinitely if komorebi was unresponsive)
- Async message sending via `std::thread::spawn` so workspace/layout changes never block the UI thread
- 50ms event debouncing with duplicate filtering — batches rapid state changes and skips no-ops, eliminating redundant UI redraws
- Reconnect loop: auto-reconnects to komorebi after disconnection instead of silently stopping
- Proper `PartialEq`/`Eq` derives on State/Monitor/Workspace/Rect for reliable state comparison

### Uniform workspace button widths (9d39cbb, 5623e58)
- Added `width_opt()` builder to WorkspaceButton widget
- Switcher computes max text width across all visible workspace names, applies uniform width to all buttons for consistent visual alignment

### Highlight focused workspace config option (c28c437, a9a89db)
- Added `highlight_focused_workspace` to Config (global, default `true` for backward-compatible behavior) and MonitorConfig (per-monitor `Option<bool>` override)
- Added `highlight_focused_opt()` builder to Windows WorkspaceButton widget and `highlight_focused` parameter to macOS WorkspaceButton
- Settings UI: global checkbox + per-monitor Inherit/Enable/Disable combo
- When enabled: focused workspace button shows subtle background highlight; when disabled: only the indicator bar (and hover) provides visual feedback

### Config resolution refactoring (1be2459)
- Introduced `ResolvedMonitorConfig` to resolve monitor→global config fallbacks at a single point
- Eliminated duplicated `unwrap_or` chains across switcher UI, macOS delegate, and font loading
- Per-frame full-Config clone replaced with lightweight resolved-config read

### Dark mode detection fix (1be2459)
- Replaced foreground-color==white heuristic with canonical `AppsUseLightTheme` registry key. Correct under high-contrast and custom themes.

### Win32 correctness fixes (88b2e92)
- `RegisterClassW` guarded with `OnceLock` to prevent repeated class registration per monitor
- Renderer `panic!` replaced with `debug_assert!` + graceful return for release builds
- Merged duplicate `CloseRequested`/`Destroyed` handler blocks, eliminated dead code path

### Version bump to 0.10.3 (8f51e0b)