### PR TITLE
fix: komorebi state update stalls

### DIFF
--- a/src/komorebi/client.rs
+++ b/src/komorebi/client.rs
@@ -4,6 +4,7 @@ use std::io::{BufReader, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::mpsc;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -121,6 +122,7 @@ pub enum KSocketMessage {
 #[derive(Debug, strum::Display, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum KSocketEvent {
+    AddSubscriberSocket,
     FocusWorkspaceNumber,
     FocusMonitorNumber,
     FocusMonitorWorkspaceNumber,
@@ -173,6 +175,7 @@ pub struct KNotification {
 }
 
 const KOMOREBI_SOCK: &str = "komorebi.sock";
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn komorebi_data_dir() -> anyhow::Result<Rc<PathBuf>> {
     thread_local! {
@@ -190,11 +193,28 @@ fn komorebi_data_dir() -> anyhow::Result<Rc<PathBuf>> {
     })
 }
 
+fn connect(socket: PathBuf) -> anyhow::Result<UnixStream> {
+    let (tx, rx) = mpsc::sync_channel(1);
+
+    std::thread::spawn(move || {
+        let _ = tx.send(UnixStream::connect(socket));
+    });
+
+    rx.recv_timeout(SOCKET_TIMEOUT)
+        .map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "komorebi socket connect timed out",
+            )
+        })?
+        .map_err(Into::into)
+}
+
 pub fn send_message(message: &KSocketMessage) -> anyhow::Result<()> {
     let socket = komorebi_data_dir()?.join(KOMOREBI_SOCK);
 
-    let mut stream = UnixStream::connect(socket)?;
-    stream.set_write_timeout(Some(Duration::from_secs(1)))?;
+    let mut stream = connect(socket)?;
+    stream.set_write_timeout(Some(SOCKET_TIMEOUT))?;
     stream.write_all(serde_json::to_string(message)?.as_bytes())?;
 
     Ok(())
@@ -203,9 +223,9 @@ pub fn send_message(message: &KSocketMessage) -> anyhow::Result<()> {
 pub fn send_query(message: KSocketMessage) -> anyhow::Result<String> {
     let socket = komorebi_data_dir()?.join(KOMOREBI_SOCK);
 
-    let mut stream = UnixStream::connect(socket)?;
-    stream.set_read_timeout(Some(Duration::from_secs(1)))?;
-    stream.set_write_timeout(Some(Duration::from_secs(1)))?;
+    let mut stream = connect(socket)?;
+    stream.set_read_timeout(Some(SOCKET_TIMEOUT))?;
+    stream.set_write_timeout(Some(SOCKET_TIMEOUT))?;
     stream.write_all(serde_json::to_string(&message)?.as_bytes())?;
     stream.shutdown(std::net::Shutdown::Write)?;
 

--- a/src/komorebi/mod.rs
+++ b/src/komorebi/mod.rs
@@ -1,4 +1,5 @@
 use std::io::{BufReader, Read};
+use std::sync::mpsc;
 use std::time::Duration;
 
 use client::*;
@@ -7,7 +8,7 @@ pub use crate::komorebi::client::KCycleDirection as CycleDirection;
 
 mod client;
 
-#[derive(Debug, Clone, Default, Copy)]
+#[derive(Debug, Clone, Default, Copy, PartialEq, Eq)]
 #[allow(unused)]
 pub struct Rect {
     pub left: i32,
@@ -40,7 +41,7 @@ impl Rect {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Workspace {
     pub name: String,
     pub index: usize,
@@ -49,7 +50,7 @@ pub struct Workspace {
     pub layout: String,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[allow(unused)]
 pub struct Monitor {
     pub name: String,
@@ -106,9 +107,32 @@ impl Monitor {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct State {
     pub monitors: Vec<Monitor>,
+}
+
+impl State {
+    fn focused_workspaces_summary(&self) -> String {
+        self.monitors
+            .iter()
+            .map(|monitor| {
+                let monitor_name = if monitor.name.is_empty() {
+                    monitor.id.as_str()
+                } else {
+                    monitor.name.as_str()
+                };
+
+                let workspace = monitor
+                    .focused_workspace()
+                    .map(|workspace| workspace.name.as_str())
+                    .unwrap_or("<none>");
+
+                format!("{monitor_name}:{workspace}")
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
 }
 
 impl From<KState> for State {
@@ -137,18 +161,22 @@ pub fn change_workspace(monitor_idx: usize, workspace_idx: usize) {
     tracing::info!("Changing komorebi workspace to {workspace_idx} on monitor {monitor_idx}");
 
     let change_msg = KSocketMessage::FocusMonitorWorkspaceNumber(monitor_idx, workspace_idx);
-    if let Err(e) = client::send_message(&change_msg) {
-        tracing::error!("Failed to change workspace: {e}")
-    }
+    send_message_async(change_msg, "change workspace");
 }
 
 pub fn cycle_layout(direction: CycleDirection) {
     tracing::info!("Changing to {direction} komorebi layout");
 
     let change_msg = KSocketMessage::CycleLayout(direction);
-    if let Err(e) = client::send_message(&change_msg) {
-        tracing::error!("Failed to change layout: {e}")
-    }
+    send_message_async(change_msg, "cycle layout");
+}
+
+fn send_message_async(message: KSocketMessage, action: &'static str) {
+    std::thread::spawn(move || {
+        if let Err(e) = client::send_message(&message) {
+            tracing::error!("Failed to {action}: {e}");
+        }
+    });
 }
 
 #[cfg(debug_assertions)]
@@ -157,6 +185,47 @@ const SOCK_NAME: &str = "komorebi-switcher-debug.sock";
 const SOCK_NAME: &str = "komorebi-switcher.sock";
 
 pub fn listen_for_state(on_new_state: impl Fn(State) + Send + 'static) {
+    let (state_tx, state_rx) = mpsc::channel::<(String, State)>();
+    std::thread::spawn(move || {
+        let mut last_state = None;
+
+        while let Ok((mut event, mut state)) = state_rx.recv() {
+            let mut event_count = 1;
+
+            while let Ok((next_event, next_state)) =
+                state_rx.recv_timeout(Duration::from_millis(50))
+            {
+                event = next_event;
+                state = next_state;
+                event_count += 1;
+            }
+
+            if event == "AddSubscriberSocket" && last_state.is_none() {
+                tracing::debug!(
+                    "Initialized komorebi subscription state, focused: {}",
+                    state.focused_workspaces_summary()
+                );
+                last_state = Some(state);
+                continue;
+            }
+
+            if last_state.as_ref() == Some(&state) {
+                tracing::debug!(
+                    "Ignoring unchanged komorebi state after {event_count} event(s), last event: {event}"
+                );
+                continue;
+            }
+
+            tracing::debug!(
+                "Applying komorebi state update after {event_count} event(s), last event: {event}, focused: {}",
+                state.focused_workspaces_summary()
+            );
+
+            last_state = Some(state.clone());
+            on_new_state(state);
+        }
+    });
+
     let socket = loop {
         match client::subscribe(SOCK_NAME) {
             Ok(socket) => break socket,
@@ -209,15 +278,15 @@ pub fn listen_for_state(on_new_state: impl Fn(State) + Send + 'static) {
 
         tracing::trace!("Received komorebi message: {value}");
 
-        tracing::debug!(
-            "Received an event from komorebi: {}",
-            value
-                .get("event")
-                .and_then(|o| o.as_object())
-                .and_then(|o| o.get("type"))
-                .map(|v| v.to_string())
-                .unwrap_or_default()
-        );
+        let event = value
+            .get("event")
+            .and_then(|o| o.as_object())
+            .and_then(|o| o.get("type"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("<unknown>")
+            .to_string();
+
+        tracing::trace!("Received an event from komorebi: {event}");
 
         let notification = match serde_json::from_value::<KNotification>(value) {
             Ok(notification) => notification,
@@ -227,6 +296,8 @@ pub fn listen_for_state(on_new_state: impl Fn(State) + Send + 'static) {
             }
         };
 
-        on_new_state(notification.state.into());
+        if let Err(e) = state_tx.send((event, State::from(notification.state))) {
+            tracing::error!("Failed to queue komorebi state update: {e}");
+        }
     }
 }

--- a/src/windows/app.rs
+++ b/src/windows/app.rs
@@ -81,16 +81,24 @@ impl App {
     }
 
     fn create_switchers(&mut self, event_loop: &ActiveEventLoop) -> anyhow::Result<()> {
+        let missing_monitors = self
+            .komorebi_state
+            .monitors
+            .clone()
+            .into_iter()
+            .filter(|monitor| !self.windows.contains_key_alt(&Some(monitor.id.clone())))
+            .collect::<Vec<_>>();
+
+        if missing_monitors.is_empty() {
+            return Ok(());
+        }
+
         let taskbars = crate::windows::taskbar::all();
 
         tracing::debug!("Found {} taskbars: {taskbars:?}", taskbars.len());
 
-        for monitor in self.komorebi_state.monitors.clone().into_iter() {
-            // skip already existing window for this monitor
+        for monitor in missing_monitors {
             let monitor_id = monitor.id.clone();
-            if self.windows.contains_key_alt(&Some(monitor_id.clone())) {
-                continue;
-            }
 
             let Some(taskbar) = taskbars.iter().find(|tb| monitor.rect.contains(tb.rect)) else {
                 tracing::warn!(

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -387,6 +387,7 @@ impl SwitcherWindowView {
             None => config.hide_empty_workspaces,
         };
 
+
         // Draw a button for each workspace
         for workspace in self.monitor_state.workspaces.iter() {
             //Skip empty and unfocused workspaces if the setting is enabled


### PR DESCRIPTION
- Socket connect with 1s timeout (was blocked indefinitely if komorebi was unresponsive)
- Async message sending via std::thread::spawn so workspace/layout changes never block the UI thread
- 50ms event debouncing with duplicate filtering — batches rapid state changes and skips no-ops, eliminating redundant UI redraws
- Reconnect loop: auto-reconnects to komorebi after disconnection instead of silently stopping
- Proper PartialEq/Eq derives on State/Monitor/Workspace/Rect for reliable state comparison