### PR TITLE
feat: uniform workspace button widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ or use the settings window accessible from the context menu.
 # Global settings
 show_layout_button    = false
 hide_empty_workspaces = false
+uniform_workspace_button_widths = false
 
 [colors]
 active_indicator = "#4CC2FFCC"
@@ -53,6 +54,7 @@ busy_indicator = "rgba(180, 173, 170, 0.6)"
 [monitors.0]
 show_layout_button    = false    # Can be removed to use the global setting
 hide_empty_workspaces = false    # Can be removed to use the global setting
+uniform_workspace_button_widths = true # Can be removed to use the global setting
 auto_width            = true
 auto_height           = true
 x                     = 0

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub struct MonitorConfig {
     pub show_layout_button: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hide_empty_workspaces: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uniform_workspace_button_widths: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,
@@ -62,6 +64,7 @@ impl Default for MonitorConfig {
         Self {
             show_layout_button: None,
             hide_empty_workspaces: None,
+            uniform_workspace_button_widths: None,
             font_family: None,
             font_weight: None,
             colors: ColorsConfig::default(),
@@ -81,6 +84,8 @@ pub struct Config {
     pub show_layout_button: bool,
     #[serde(default)]
     pub hide_empty_workspaces: bool,
+    #[serde(default)]
+    pub uniform_workspace_button_widths: bool,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,

--- a/src/windows/widgets/workspace_button.rs
+++ b/src/windows/widgets/workspace_button.rs
@@ -5,6 +5,7 @@ pub struct WorkspaceButton<'a> {
     text_color: Option<egui::Color32>,
     line_active_color: Option<egui::Color32>,
     line_busy_color: Option<egui::Color32>,
+    width: Option<f32>,
     dark_mode: Option<bool>,
 }
 
@@ -15,6 +16,7 @@ impl<'a> WorkspaceButton<'a> {
             text_color: None,
             line_active_color: None,
             line_busy_color: None,
+            width: None,
             dark_mode: None,
         }
     }
@@ -36,6 +38,11 @@ impl<'a> WorkspaceButton<'a> {
 
     pub fn line_busy_color_opt(mut self, color: Option<egui::Color32>) -> Self {
         self.line_busy_color = color;
+        self
+    }
+
+    pub fn width_opt(mut self, width: Option<f32>) -> Self {
+        self.width = width;
         self
     }
 }
@@ -63,7 +70,10 @@ impl egui::Widget for WorkspaceButton<'_> {
             .painter()
             .layout_no_wrap(text, font_id.clone(), text_color);
 
-        let size = MIN_SIZE.max(text_galley.rect.size() + TEXT_PADDING);
+        let mut size = MIN_SIZE.max(text_galley.rect.size() + TEXT_PADDING);
+        if let Some(width) = self.width {
+            size.x = size.x.max(width);
+        }
 
         let (rect, response) = ui.allocate_at_least(size, egui::Sense::CLICK | egui::Sense::HOVER);
 

--- a/src/windows/windows/settings.rs
+++ b/src/windows/windows/settings.rs
@@ -92,6 +92,13 @@ impl SettingsWindowView {
         ));
     }
 
+    fn global_uniform_workspace_button_widths_ui(&mut self, ui: &mut egui::Ui) {
+        ui.add(egui::Checkbox::new(
+            &mut self.config.uniform_workspace_button_widths,
+            "Uniform workspace button widths",
+        ));
+    }
+
     fn global_font_family_ui(&mut self, ui: &mut egui::Ui) {
         ui.label("Font Family");
 
@@ -153,6 +160,9 @@ impl SettingsWindowView {
                 ui.end_row();
 
                 self.global_hide_empty_workspaces_ui(ui);
+                ui.end_row();
+
+                self.global_uniform_workspace_button_widths_ui(ui);
                 ui.end_row();
 
                 self.global_font_family_ui(ui);
@@ -252,6 +262,31 @@ impl SettingsWindowView {
 
         if before != selected {
             monitor_config.hide_empty_workspaces = selected.into();
+        }
+    }
+
+    fn uniform_workspace_button_widths_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
+        let monitor_config = self.config.get_monitor_mut(monitor_id);
+
+        ui.label("Uniform workspace button widths");
+
+        let mut selected: ActivationOption = monitor_config.uniform_workspace_button_widths.into();
+        let before = selected;
+
+        egui::ComboBox::new("uniform_workspace_button_widths", "")
+            .selected_text(format!("{}", selected))
+            .show_ui(ui, |ui| {
+                for option in [
+                    ActivationOption::Inherit,
+                    ActivationOption::Enable,
+                    ActivationOption::Disable,
+                ] {
+                    ui.selectable_value(&mut selected, option, format!("{}", option));
+                }
+            });
+
+        if before != selected {
+            monitor_config.uniform_workspace_button_widths = selected.into();
         }
     }
 
@@ -356,6 +391,9 @@ impl SettingsWindowView {
         ui.end_row();
 
         self.hide_empty_workspaces_ui(ui, monitor_id);
+        ui.end_row();
+
+        self.uniform_workspace_button_widths_ui(ui, monitor_id);
         ui.end_row();
 
         self.font_family_ui(ui, monitor_id);

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -335,6 +335,7 @@ impl SwitcherWindowView {
         workspace: &crate::komorebi::Workspace,
         monitor_config: &crate::config::MonitorConfig,
         config: &Config,
+        uniform_width: Option<f32>,
     ) {
         // Determine active indicator colors,
         // with monitor config taking precedence over global config,
@@ -364,6 +365,7 @@ impl SwitcherWindowView {
             .dark_mode(Some(self.is_system_dark_mode()))
             .line_active_color_opt(active_indicator_color)
             .line_busy_color_opt(busy_indicator_color)
+            .width_opt(uniform_width)
             .text_color_opt(self.forgreound_color);
 
         if ui.add(btn).clicked() {
@@ -387,14 +389,37 @@ impl SwitcherWindowView {
             None => config.hide_empty_workspaces,
         };
 
-        // Draw a button for each workspace
-        for workspace in self.monitor_state.workspaces.iter() {
-            //Skip empty and unfocused workspaces if the setting is enabled
-            if hide_empty_workspaces && workspace.is_empty && !workspace.focused {
-                continue;
-            }
+        let visible_workspaces = self
+            .monitor_state
+            .workspaces
+            .iter()
+            .filter(|workspace| !(hide_empty_workspaces && workspace.is_empty && !workspace.focused))
+            .collect::<Vec<_>>();
 
-            self.workspace_button(ui, workspace, monitor_config, config);
+        let uniform_width = {
+            const MIN_WIDTH: f32 = 28.0;
+            const HORIZONTAL_TEXT_PADDING: f32 = 16.0;
+
+            let max_text_width = visible_workspaces
+                .iter()
+                .map(|workspace| {
+                    ui.painter()
+                        .layout_no_wrap(
+                            workspace.name.clone(),
+                            egui::FontId::default(),
+                            egui::Color32::TRANSPARENT,
+                        )
+                        .rect
+                        .width()
+                })
+                .fold(0.0, f32::max);
+
+            Some((max_text_width + HORIZONTAL_TEXT_PADDING).max(MIN_WIDTH))
+        };
+
+        // Draw a button for each workspace
+        for workspace in visible_workspaces {
+            self.workspace_button(ui, workspace, monitor_config, config, uniform_width);
         }
 
         // Show layout button for focused workspace if the setting is enabled

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -166,6 +166,30 @@ impl SwitcherWindowView {
             self.accent_color
         }
     }
+
+    fn uniform_workspace_button_width<'a>(
+        &self,
+        ui: &egui::Ui,
+        workspaces: impl Iterator<Item = &'a crate::komorebi::Workspace>,
+    ) -> f32 {
+        const MIN_WIDTH: f32 = 28.0;
+        const HORIZONTAL_TEXT_PADDING: f32 = 16.0;
+
+        let max_text_width = workspaces
+            .map(|workspace| {
+                ui.painter()
+                    .layout_no_wrap(
+                        workspace.name.clone(),
+                        egui::FontId::default(),
+                        egui::Color32::TRANSPARENT,
+                    )
+                    .rect
+                    .width()
+            })
+            .fold(0.0, f32::max);
+
+        (max_text_width + HORIZONTAL_TEXT_PADDING).max(MIN_WIDTH)
+    }
 }
 
 /// Actions
@@ -393,29 +417,17 @@ impl SwitcherWindowView {
             .monitor_state
             .workspaces
             .iter()
-            .filter(|workspace| !(hide_empty_workspaces && workspace.is_empty && !workspace.focused))
+            .filter(|workspace| {
+                !(hide_empty_workspaces && workspace.is_empty && !workspace.focused)
+            })
             .collect::<Vec<_>>();
 
-        let uniform_width = {
-            const MIN_WIDTH: f32 = 28.0;
-            const HORIZONTAL_TEXT_PADDING: f32 = 16.0;
-
-            let max_text_width = visible_workspaces
-                .iter()
-                .map(|workspace| {
-                    ui.painter()
-                        .layout_no_wrap(
-                            workspace.name.clone(),
-                            egui::FontId::default(),
-                            egui::Color32::TRANSPARENT,
-                        )
-                        .rect
-                        .width()
-                })
-                .fold(0.0, f32::max);
-
-            Some((max_text_width + HORIZONTAL_TEXT_PADDING).max(MIN_WIDTH))
+        let uniform_workspace_button_widths = match monitor_config.uniform_workspace_button_widths {
+            Some(uniform_widths) => uniform_widths,
+            None => config.uniform_workspace_button_widths,
         };
+        let uniform_width = uniform_workspace_button_widths
+            .then(|| self.uniform_workspace_button_width(ui, visible_workspaces.iter().copied()));
 
         // Draw a button for each workspace
         for workspace in visible_workspaces {


### PR DESCRIPTION
- Added width_opt() builder to WorkspaceButton widget
- Switcher computes max text width across all visible workspace names, applies uniform width to all buttons for consistent visual alignment
