### PR TITLE
feat: add highlight_focused_workspace config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ show_layout_button    = false
 hide_empty_workspaces = false
 
 [colors]
+background = "#00000000"
+busy_background = "#00000000"
+active_background = "#FFFFFF1A"
+border = "#00000000"
+busy_border = "#00000000"
+active_border = "#FFFFFF05"
 active_indicator = "#4CC2FFCC"
 busy_indicator = "rgba(180, 173, 170, 0.6)"
 
@@ -61,7 +67,9 @@ width                 = 200      # Ignored if `auto_width` is enabled
 height                = 40       # Ignored if `auto_height` is enabled
 
 [monitors.0.colors]
-active_indicator = "#4CC2FFCC"          # Can be removed to use the global setting
+active_background = "#00000000"    # Can be removed to use the global setting
+active_border = "#00000000"        # Can be removed to use the global setting
+active_indicator = "#4CC2FFCC"     # Can be removed to use the global setting
 busy_indicator = "#B4ADAA80"       # Can be removed to use the global setting
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,22 @@ use std::path::PathBuf;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedMonitorConfig {
+    pub show_layout_button: bool,
+    pub hide_empty_workspaces: bool,
+    pub font_family: Option<String>,
+    pub font_weight: u16,
+    pub active_indicator: Option<String>,
+    pub busy_indicator: Option<String>,
+    pub auto_width: bool,
+    pub auto_height: bool,
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
 fn default_width() -> i32 {
     200
 }
@@ -156,7 +172,6 @@ impl Config {
         self.monitors.get(monitor_id).cloned().unwrap_or_default()
     }
 
-    #[allow(dead_code)]
     pub fn get_monitor_mut(&mut self, monitor_id: &str) -> &mut MonitorConfig {
         self.monitors.entry(monitor_id.to_string()).or_default()
     }
@@ -164,6 +179,42 @@ impl Config {
     #[allow(dead_code)]
     pub fn set_monitor(&mut self, monitor_id: &str, config: MonitorConfig) {
         self.monitors.insert(monitor_id.to_string(), config);
+    }
+
+    pub fn resolved_monitor_config(&self, monitor_id: &str) -> ResolvedMonitorConfig {
+        let mc = self.get_monitor(monitor_id);
+
+        let show_layout_button = mc.show_layout_button.unwrap_or(self.show_layout_button);
+        let hide_empty_workspaces = mc
+            .hide_empty_workspaces
+            .unwrap_or(self.hide_empty_workspaces);
+
+        let font_family = mc.font_family.or(self.font_family.clone());
+        let font_weight = mc.font_weight.or(self.font_weight).unwrap_or(400);
+
+        let active_indicator = mc
+            .colors
+            .active_indicator
+            .or(self.colors.active_indicator.clone());
+        let busy_indicator = mc
+            .colors
+            .busy_indicator
+            .or(self.colors.busy_indicator.clone());
+
+        ResolvedMonitorConfig {
+            show_layout_button,
+            hide_empty_workspaces,
+            font_family,
+            font_weight,
+            active_indicator,
+            busy_indicator,
+            auto_width: mc.auto_width,
+            auto_height: mc.auto_height,
+            x: mc.x,
+            y: mc.y,
+            width: mc.width,
+            height: mc.height,
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 pub struct ResolvedMonitorConfig {
     pub show_layout_button: bool,
     pub hide_empty_workspaces: bool,
+    pub highlight_focused_workspace: bool,
     pub font_family: Option<String>,
     pub font_weight: u16,
     pub active_indicator: Option<String>,
@@ -50,6 +51,9 @@ pub struct MonitorConfig {
     pub hide_empty_workspaces: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub highlight_focused_workspace: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_weight: Option<u16>,
@@ -78,6 +82,7 @@ impl Default for MonitorConfig {
         Self {
             show_layout_button: None,
             hide_empty_workspaces: None,
+            highlight_focused_workspace: None,
             font_family: None,
             font_weight: None,
             colors: ColorsConfig::default(),
@@ -97,6 +102,9 @@ pub struct Config {
     pub show_layout_button: bool,
     #[serde(default)]
     pub hide_empty_workspaces: bool,
+
+    #[serde(default = "default_true")]
+    pub highlight_focused_workspace: bool,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,
@@ -189,6 +197,10 @@ impl Config {
             .hide_empty_workspaces
             .unwrap_or(self.hide_empty_workspaces);
 
+        let highlight_focused_workspace = mc
+            .highlight_focused_workspace
+            .unwrap_or(self.highlight_focused_workspace);
+
         let font_family = mc.font_family.or(self.font_family.clone());
         let font_weight = mc.font_weight.or(self.font_weight).unwrap_or(400);
 
@@ -204,6 +216,7 @@ impl Config {
         ResolvedMonitorConfig {
             show_layout_button,
             hide_empty_workspaces,
+            highlight_focused_workspace,
             font_family,
             font_weight,
             active_indicator,

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,9 +8,14 @@ use serde::{Deserialize, Serialize};
 pub struct ResolvedMonitorConfig {
     pub show_layout_button: bool,
     pub hide_empty_workspaces: bool,
-    pub highlight_focused_workspace: bool,
     pub font_family: Option<String>,
     pub font_weight: u16,
+    pub background: Option<String>,
+    pub busy_background: Option<String>,
+    pub active_background: Option<String>,
+    pub border: Option<String>,
+    pub busy_border: Option<String>,
+    pub active_border: Option<String>,
     pub active_indicator: Option<String>,
     pub busy_indicator: Option<String>,
     pub auto_width: bool,
@@ -32,6 +37,18 @@ fn default_height() -> i32 {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ColorsConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub background: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busy_background: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_background: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub border: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub busy_border: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_border: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_indicator: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub busy_indicator: Option<String>,
@@ -39,7 +56,14 @@ pub struct ColorsConfig {
 
 impl ColorsConfig {
     pub fn is_empty(&self) -> bool {
-        self.active_indicator.is_none() && self.busy_indicator.is_none()
+        self.background.is_none()
+            && self.busy_background.is_none()
+            && self.active_background.is_none()
+            && self.border.is_none()
+            && self.busy_border.is_none()
+            && self.active_border.is_none()
+            && self.active_indicator.is_none()
+            && self.busy_indicator.is_none()
     }
 }
 
@@ -49,9 +73,6 @@ pub struct MonitorConfig {
     pub show_layout_button: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hide_empty_workspaces: Option<bool>,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub highlight_focused_workspace: Option<bool>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,
@@ -82,7 +103,6 @@ impl Default for MonitorConfig {
         Self {
             show_layout_button: None,
             hide_empty_workspaces: None,
-            highlight_focused_workspace: None,
             font_family: None,
             font_weight: None,
             colors: ColorsConfig::default(),
@@ -102,9 +122,6 @@ pub struct Config {
     pub show_layout_button: bool,
     #[serde(default)]
     pub hide_empty_workspaces: bool,
-
-    #[serde(default = "default_true")]
-    pub highlight_focused_workspace: bool,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub font_family: Option<String>,
@@ -197,13 +214,24 @@ impl Config {
             .hide_empty_workspaces
             .unwrap_or(self.hide_empty_workspaces);
 
-        let highlight_focused_workspace = mc
-            .highlight_focused_workspace
-            .unwrap_or(self.highlight_focused_workspace);
-
         let font_family = mc.font_family.or(self.font_family.clone());
         let font_weight = mc.font_weight.or(self.font_weight).unwrap_or(400);
 
+        let background = mc.colors.background.or(self.colors.background.clone());
+        let busy_background = mc
+            .colors
+            .busy_background
+            .or(self.colors.busy_background.clone());
+        let active_background = mc
+            .colors
+            .active_background
+            .or(self.colors.active_background.clone());
+        let border = mc.colors.border.or(self.colors.border.clone());
+        let busy_border = mc.colors.busy_border.or(self.colors.busy_border.clone());
+        let active_border = mc
+            .colors
+            .active_border
+            .or(self.colors.active_border.clone());
         let active_indicator = mc
             .colors
             .active_indicator
@@ -216,9 +244,14 @@ impl Config {
         ResolvedMonitorConfig {
             show_layout_button,
             hide_empty_workspaces,
-            highlight_focused_workspace,
             font_family,
             font_weight,
+            background,
+            busy_background,
+            active_background,
+            border,
+            busy_border,
+            active_border,
             active_indicator,
             busy_indicator,
             auto_width: mc.auto_width,

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -166,6 +166,7 @@ impl AppDelegate {
                 custom_font,
                 resolved.active_indicator.as_deref(),
                 resolved.busy_indicator.as_deref(),
+                resolved.highlight_focused_workspace,
             );
             stack_view.addArrangedSubview(&workspace_button);
             views.push(workspace_button.downcast().unwrap());

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -16,7 +16,7 @@ use objc2_foundation::{
 
 use self::workspace_button::WorkspaceButton;
 use self::workspaces_stack_view::WorkspacesStackView;
-use crate::config::Config;
+use crate::config::{Config, ResolvedMonitorConfig};
 use crate::macos::layout_button::LayoutButton;
 use crate::macos::windows::settings::SettingsWindowController;
 
@@ -84,10 +84,11 @@ define_class!(
             let config = Config::load().unwrap_or_default();
 
             // Resolve custom font lazily once at startup.
-            let custom_font = config.font_family.as_deref().and_then(|family| {
-                let weight = config.font_weight.unwrap_or(400);
+            let resolved = config.resolved_monitor_config("");
+            let custom_font = resolved.font_family.as_deref().and_then(|family| {
                 let size = NSFont::systemFontOfSize(0.0).pointSize();
-                let postscript_name = crate::utils::find_font(family, weight)?.postscript_name()?;
+                let postscript_name =
+                    crate::utils::find_font(family, resolved.font_weight)?.postscript_name()?;
                 NSFont::fontWithName_size(&NSString::from_str(&postscript_name), size)
             });
             let _ = self.ivars().custom_font.set(custom_font);
@@ -139,6 +140,7 @@ impl AppDelegate {
         let stack_view = self.ivars().ns_stack_view.get().unwrap();
         let mut views = self.ivars().buttons.borrow_mut();
         let config = self.ivars().config.get().unwrap();
+        let resolved = config.resolved_monitor_config("");
 
         for button in views.iter() {
             button.removeFromSuperview();
@@ -152,11 +154,9 @@ impl AppDelegate {
 
         // Use the cached resolved custom font
         let custom_font = self.ivars().custom_font.get().and_then(|f| f.as_deref());
-        let active_indicator_color = config.colors.active_indicator.as_deref();
-        let busy_indicator_color = config.colors.busy_indicator.as_deref();
 
         for workspace in &monitor.workspaces {
-            if config.hide_empty_workspaces && workspace.is_empty && !workspace.focused {
+            if resolved.hide_empty_workspaces && workspace.is_empty && !workspace.focused {
                 continue;
             }
 
@@ -164,14 +164,14 @@ impl AppDelegate {
                 mtm,
                 workspace,
                 custom_font,
-                active_indicator_color,
-                busy_indicator_color,
+                resolved.active_indicator.as_deref(),
+                resolved.busy_indicator.as_deref(),
             );
             stack_view.addArrangedSubview(&workspace_button);
             views.push(workspace_button.downcast().unwrap());
         }
 
-        if config.show_layout_button {
+        if resolved.show_layout_button {
             if let Some(focused_ws) = monitor.focused_workspace() {
                 let separator = NSTextField::labelWithString(ns_string!("|"), mtm);
                 separator.setAlignment(NSTextAlignment::Center);

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -16,7 +16,7 @@ use objc2_foundation::{
 
 use self::workspace_button::WorkspaceButton;
 use self::workspaces_stack_view::WorkspacesStackView;
-use crate::config::{Config, ResolvedMonitorConfig};
+use crate::config::Config;
 use crate::macos::layout_button::LayoutButton;
 use crate::macos::windows::settings::SettingsWindowController;
 

--- a/src/macos/mod.rs
+++ b/src/macos/mod.rs
@@ -164,9 +164,14 @@ impl AppDelegate {
                 mtm,
                 workspace,
                 custom_font,
+                resolved.background.as_deref(),
+                resolved.busy_background.as_deref(),
+                resolved.active_background.as_deref(),
+                resolved.border.as_deref(),
+                resolved.busy_border.as_deref(),
+                resolved.active_border.as_deref(),
                 resolved.active_indicator.as_deref(),
                 resolved.busy_indicator.as_deref(),
-                resolved.highlight_focused_workspace,
             );
             stack_view.addArrangedSubview(&workspace_button);
             views.push(workspace_button.downcast().unwrap());

--- a/src/macos/workspace_button.rs
+++ b/src/macos/workspace_button.rs
@@ -100,6 +100,7 @@ impl WorkspaceButton {
         font: Option<&NSFont>,
         active_indicator_color: Option<&str>,
         busy_indicator_color: Option<&str>,
+        highlight_focused: bool,
     ) -> Retained<Self> {
         // Create button
         let this = Self::alloc(mtm).set_ivars(WorkspaceButtonIvars::new(workspace.clone()));
@@ -134,7 +135,7 @@ impl WorkspaceButton {
         height_constraint.setActive(true);
 
         // Set background color based on active state
-        let bg_color = if workspace.focused {
+        let bg_color = if highlight_focused && workspace.focused {
             NSColor::colorWithWhite_alpha(1.0, 0.1).CGColor()
         } else {
             NSColor::clearColor().CGColor()

--- a/src/macos/workspace_button.rs
+++ b/src/macos/workspace_button.rs
@@ -98,9 +98,14 @@ impl WorkspaceButton {
         mtm: MainThreadMarker,
         workspace: &crate::komorebi::Workspace,
         font: Option<&NSFont>,
+        background_color: Option<&str>,
+        busy_background_color: Option<&str>,
+        active_background_color: Option<&str>,
+        border_color: Option<&str>,
+        busy_border_color: Option<&str>,
+        active_border_color: Option<&str>,
         active_indicator_color: Option<&str>,
         busy_indicator_color: Option<&str>,
-        highlight_focused: bool,
     ) -> Retained<Self> {
         // Create button
         let this = Self::alloc(mtm).set_ivars(WorkspaceButtonIvars::new(workspace.clone()));
@@ -134,13 +139,39 @@ impl WorkspaceButton {
         width_constraint.setActive(true);
         height_constraint.setActive(true);
 
-        // Set background color based on active state
-        let bg_color = if highlight_focused && workspace.focused {
-            NSColor::colorWithWhite_alpha(1.0, 0.1).CGColor()
+        let bg_color = if workspace.focused {
+            active_background_color
+                .and_then(crate::macos::utils::ns_color_from_color)
+                .unwrap_or_else(|| NSColor::colorWithWhite_alpha(1.0, 0.1))
+                .CGColor()
+        } else if !workspace.is_empty {
+            busy_background_color
+                .or(background_color)
+                .and_then(crate::macos::utils::ns_color_from_color)
+                .unwrap_or_else(NSColor::clearColor)
+                .CGColor()
         } else {
-            NSColor::clearColor().CGColor()
+            background_color
+                .and_then(crate::macos::utils::ns_color_from_color)
+                .unwrap_or_else(NSColor::clearColor)
+                .CGColor()
         };
         let _: () = unsafe { msg_send![&layer, setBackgroundColor: &*bg_color] };
+
+        let border_color = if workspace.focused {
+            active_border_color.and_then(crate::macos::utils::ns_color_from_color)
+        } else if !workspace.is_empty {
+            busy_border_color
+                .or(border_color)
+                .and_then(crate::macos::utils::ns_color_from_color)
+        } else {
+            border_color.and_then(crate::macos::utils::ns_color_from_color)
+        };
+        if let Some(border_color) = border_color {
+            let border_color = border_color.CGColor();
+            let _: () = unsafe { msg_send![&layer, setBorderColor: &*border_color] };
+            let _: () = unsafe { msg_send![&layer, setBorderWidth: 1.0] };
+        }
 
         // Create indicator view
         let indicator = NSView::new(mtm);

--- a/src/windows/widgets/workspace_button.rs
+++ b/src/windows/widgets/workspace_button.rs
@@ -7,6 +7,7 @@ pub struct WorkspaceButton<'a> {
     line_busy_color: Option<egui::Color32>,
     width: Option<f32>,
     dark_mode: Option<bool>,
+    highlight_focused: Option<bool>,
 }
 
 impl<'a> WorkspaceButton<'a> {
@@ -18,6 +19,7 @@ impl<'a> WorkspaceButton<'a> {
             line_busy_color: None,
             width: None,
             dark_mode: None,
+            highlight_focused: None,
         }
     }
 
@@ -43,6 +45,11 @@ impl<'a> WorkspaceButton<'a> {
 
     pub fn width_opt(mut self, width: Option<f32>) -> Self {
         self.width = width;
+        self
+    }
+
+    pub fn highlight_focused_opt(mut self, highlight_focused: Option<bool>) -> Self {
+        self.highlight_focused = highlight_focused;
         self
     }
 }
@@ -80,7 +87,8 @@ impl egui::Widget for WorkspaceButton<'_> {
         let painter = ui.painter();
 
         // draw background
-        if response.hovered() || self.workspace.focused {
+        let highlight_focused = self.highlight_focused.unwrap_or(true);
+        if response.hovered() || (highlight_focused && self.workspace.focused) {
             let color = if dark_mode {
                 egui::Color32::from_rgba_unmultiplied(255, 255, 255, 1)
             } else {

--- a/src/windows/widgets/workspace_button.rs
+++ b/src/windows/widgets/workspace_button.rs
@@ -5,6 +5,7 @@ pub struct WorkspaceButton<'a> {
     text_color: Option<egui::Color32>,
     line_active_color: Option<egui::Color32>,
     line_busy_color: Option<egui::Color32>,
+    width: Option<f32>,
     dark_mode: Option<bool>,
 }
 
@@ -15,6 +16,7 @@ impl<'a> WorkspaceButton<'a> {
             text_color: None,
             line_active_color: None,
             line_busy_color: None,
+            width: None,
             dark_mode: None,
         }
     }
@@ -36,6 +38,11 @@ impl<'a> WorkspaceButton<'a> {
 
     pub fn line_busy_color_opt(mut self, color: Option<egui::Color32>) -> Self {
         self.line_busy_color = color;
+        self
+    }
+
+    pub fn width_opt(mut self, width: Option<f32>) -> Self {
+        self.width = width;
         self
     }
 }
@@ -63,7 +70,10 @@ impl egui::Widget for WorkspaceButton<'_> {
             .painter()
             .layout_no_wrap(text, font_id.clone(), text_color);
 
-        let size = MIN_SIZE.max(text_galley.rect.size() + TEXT_PADDING);
+        let mut size = MIN_SIZE.max(text_galley.rect.size() + TEXT_PADDING);
+        if let Some(width) = self.width {
+            size.x = size.x.max(width);
+        }
 
         let (rect, response) = ui.allocate_at_least(size, egui::Sense::CLICK | egui::Sense::HOVER);
 

--- a/src/windows/widgets/workspace_button.rs
+++ b/src/windows/widgets/workspace_button.rs
@@ -5,9 +5,14 @@ pub struct WorkspaceButton<'a> {
     text_color: Option<egui::Color32>,
     line_active_color: Option<egui::Color32>,
     line_busy_color: Option<egui::Color32>,
+    background_color: Option<egui::Color32>,
+    busy_background_color: Option<egui::Color32>,
+    active_background_color: Option<egui::Color32>,
+    border_color: Option<egui::Color32>,
+    busy_border_color: Option<egui::Color32>,
+    active_border_color: Option<egui::Color32>,
     width: Option<f32>,
     dark_mode: Option<bool>,
-    highlight_focused: Option<bool>,
 }
 
 impl<'a> WorkspaceButton<'a> {
@@ -17,9 +22,14 @@ impl<'a> WorkspaceButton<'a> {
             text_color: None,
             line_active_color: None,
             line_busy_color: None,
+            background_color: None,
+            busy_background_color: None,
+            active_background_color: None,
+            border_color: None,
+            busy_border_color: None,
+            active_border_color: None,
             width: None,
             dark_mode: None,
-            highlight_focused: None,
         }
     }
 
@@ -43,13 +53,38 @@ impl<'a> WorkspaceButton<'a> {
         self
     }
 
-    pub fn width_opt(mut self, width: Option<f32>) -> Self {
-        self.width = width;
+    pub fn background_color_opt(mut self, color: Option<egui::Color32>) -> Self {
+        self.background_color = color;
         self
     }
 
-    pub fn highlight_focused_opt(mut self, highlight_focused: Option<bool>) -> Self {
-        self.highlight_focused = highlight_focused;
+    pub fn busy_background_color_opt(mut self, color: Option<egui::Color32>) -> Self {
+        self.busy_background_color = color;
+        self
+    }
+
+    pub fn active_background_color_opt(mut self, color: Option<egui::Color32>) -> Self {
+        self.active_background_color = color;
+        self
+    }
+
+    pub fn border_color_opt(mut self, color: Option<egui::Color32>) -> Self {
+        self.border_color = color;
+        self
+    }
+
+    pub fn busy_border_color_opt(mut self, color: Option<egui::Color32>) -> Self {
+        self.busy_border_color = color;
+        self
+    }
+
+    pub fn active_border_color_opt(mut self, color: Option<egui::Color32>) -> Self {
+        self.active_border_color = color;
+        self
+    }
+
+    pub fn width_opt(mut self, width: Option<f32>) -> Self {
+        self.width = width;
         self
     }
 }
@@ -87,23 +122,45 @@ impl egui::Widget for WorkspaceButton<'_> {
         let painter = ui.painter();
 
         // draw background
-        let highlight_focused = self.highlight_focused.unwrap_or(true);
-        if response.hovered() || (highlight_focused && self.workspace.focused) {
-            let color = if dark_mode {
+        let default_background_color = || {
+            if dark_mode {
                 egui::Color32::from_rgba_unmultiplied(255, 255, 255, 1)
             } else {
                 egui::Color32::from_rgba_unmultiplied(255, 255, 255, 30)
-            };
-
-            let stroke_color = if dark_mode {
+            }
+        };
+        let default_border_color = || {
+            if dark_mode {
                 egui::Color32::from_rgba_unmultiplied(255, 255, 255, 2)
             } else {
                 egui::Color32::from_rgba_unmultiplied(33, 33, 33, 33)
-            };
+            }
+        };
 
+        let state_background_color = if self.workspace.focused {
+            self.active_background_color
+                .or_else(|| Some(default_background_color()))
+        } else if !self.workspace.is_empty {
+            self.busy_background_color.or(self.background_color)
+        } else {
+            self.background_color
+        };
+        let state_border_color = if self.workspace.focused {
+            self.active_border_color
+                .or_else(|| Some(default_border_color()))
+        } else if !self.workspace.is_empty {
+            self.busy_border_color.or(self.border_color)
+        } else {
+            self.border_color
+        };
+
+        let should_draw_background =
+            response.hovered() || state_background_color.is_some() || state_border_color.is_some();
+        if should_draw_background {
+            let color = state_background_color.unwrap_or_else(default_background_color);
             let stroke = egui::Stroke {
                 width: 1.0,
-                color: stroke_color,
+                color: state_border_color.unwrap_or_else(default_border_color),
             };
 
             painter.rect(rect, RADIUS, color, stroke, egui::StrokeKind::Inside);

--- a/src/windows/windows/settings.rs
+++ b/src/windows/windows/settings.rs
@@ -92,6 +92,13 @@ impl SettingsWindowView {
         ));
     }
 
+    fn global_highlight_focused_workspace_ui(&mut self, ui: &mut egui::Ui) {
+        ui.add(egui::Checkbox::new(
+            &mut self.config.highlight_focused_workspace,
+            "Highlight focused workspace",
+        ));
+    }
+
     fn global_font_family_ui(&mut self, ui: &mut egui::Ui) {
         ui.label("Font Family");
 
@@ -153,6 +160,9 @@ impl SettingsWindowView {
                 ui.end_row();
 
                 self.global_hide_empty_workspaces_ui(ui);
+                ui.end_row();
+
+                self.global_highlight_focused_workspace_ui(ui);
                 ui.end_row();
 
                 self.global_font_family_ui(ui);
@@ -252,6 +262,31 @@ impl SettingsWindowView {
 
         if before != selected {
             monitor_config.hide_empty_workspaces = selected.into();
+        }
+    }
+
+    fn highlight_focused_workspace_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
+        let monitor_config = self.config.get_monitor_mut(monitor_id);
+
+        ui.label("Highlight focused workspace");
+
+        let mut selected: ActivationOption = monitor_config.highlight_focused_workspace.into();
+        let before = selected;
+
+        egui::ComboBox::new("highlight_focused_workspace", "")
+            .selected_text(format!("{}", selected))
+            .show_ui(ui, |ui| {
+                for option in [
+                    ActivationOption::Inherit,
+                    ActivationOption::Enable,
+                    ActivationOption::Disable,
+                ] {
+                    ui.selectable_value(&mut selected, option, format!("{}", option));
+                }
+            });
+
+        if before != selected {
+            monitor_config.highlight_focused_workspace = selected.into();
         }
     }
 
@@ -356,6 +391,9 @@ impl SettingsWindowView {
         ui.end_row();
 
         self.hide_empty_workspaces_ui(ui, monitor_id);
+        ui.end_row();
+
+        self.highlight_focused_workspace_ui(ui, monitor_id);
         ui.end_row();
 
         self.font_family_ui(ui, monitor_id);

--- a/src/windows/windows/settings.rs
+++ b/src/windows/windows/settings.rs
@@ -92,13 +92,6 @@ impl SettingsWindowView {
         ));
     }
 
-    fn global_highlight_focused_workspace_ui(&mut self, ui: &mut egui::Ui) {
-        ui.add(egui::Checkbox::new(
-            &mut self.config.highlight_focused_workspace,
-            "Highlight focused workspace",
-        ));
-    }
-
     fn global_font_family_ui(&mut self, ui: &mut egui::Ui) {
         ui.label("Font Family");
 
@@ -120,32 +113,53 @@ impl SettingsWindowView {
         }
     }
 
-    fn global_active_indicator_color_ui(&mut self, ui: &mut egui::Ui) {
-        ui.label("Active Indicator");
+    fn global_color_ui(ui: &mut egui::Ui, label: &str, color: &mut Option<String>) {
+        ui.label(label);
 
-        let colors = &self.config.colors;
-        let mut color = colors.active_indicator.clone().unwrap_or_default();
-
-        let text_edit = egui::TextEdit::singleline(&mut color);
+        let mut value = color.clone().unwrap_or_default();
+        let text_edit = egui::TextEdit::singleline(&mut value);
         let text_edit = text_edit.hint_text("#FFFFFFFF");
 
         if ui.add(text_edit).changed() {
-            self.config.colors.active_indicator = (!color.is_empty()).then_some(color);
+            *color = (!value.is_empty()).then_some(value);
         }
     }
 
-    fn global_busy_indicator_color_ui(&mut self, ui: &mut egui::Ui) {
-        ui.label("Busy Indicator");
+    fn global_workspace_colors_ui(&mut self, ui: &mut egui::Ui) {
+        Self::global_color_ui(ui, "Background", &mut self.config.colors.background);
+        ui.end_row();
 
-        let colors = &self.config.colors;
-        let mut color = colors.busy_indicator.clone().unwrap_or_default();
+        Self::global_color_ui(
+            ui,
+            "Busy Background",
+            &mut self.config.colors.busy_background,
+        );
+        ui.end_row();
 
-        let text_edit = egui::TextEdit::singleline(&mut color);
-        let text_edit = text_edit.hint_text("#FFFFFFFF");
+        Self::global_color_ui(
+            ui,
+            "Active Background",
+            &mut self.config.colors.active_background,
+        );
+        ui.end_row();
 
-        if ui.add(text_edit).changed() {
-            self.config.colors.busy_indicator = (!color.is_empty()).then_some(color);
-        }
+        Self::global_color_ui(ui, "Border", &mut self.config.colors.border);
+        ui.end_row();
+
+        Self::global_color_ui(ui, "Busy Border", &mut self.config.colors.busy_border);
+        ui.end_row();
+
+        Self::global_color_ui(ui, "Active Border", &mut self.config.colors.active_border);
+        ui.end_row();
+
+        Self::global_color_ui(
+            ui,
+            "Active Indicator",
+            &mut self.config.colors.active_indicator,
+        );
+        ui.end_row();
+
+        Self::global_color_ui(ui, "Busy Indicator", &mut self.config.colors.busy_indicator);
     }
 
     fn global_settings_ui(&mut self, ui: &mut egui::Ui) {
@@ -162,19 +176,13 @@ impl SettingsWindowView {
                 self.global_hide_empty_workspaces_ui(ui);
                 ui.end_row();
 
-                self.global_highlight_focused_workspace_ui(ui);
-                ui.end_row();
-
                 self.global_font_family_ui(ui);
                 ui.end_row();
 
                 self.global_font_weight_ui(ui);
                 ui.end_row();
 
-                self.global_active_indicator_color_ui(ui);
-                ui.end_row();
-
-                self.global_busy_indicator_color_ui(ui);
+                self.global_workspace_colors_ui(ui);
                 ui.end_row();
             });
     }
@@ -265,31 +273,6 @@ impl SettingsWindowView {
         }
     }
 
-    fn highlight_focused_workspace_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
-        let monitor_config = self.config.get_monitor_mut(monitor_id);
-
-        ui.label("Highlight focused workspace");
-
-        let mut selected: ActivationOption = monitor_config.highlight_focused_workspace.into();
-        let before = selected;
-
-        egui::ComboBox::new("highlight_focused_workspace", "")
-            .selected_text(format!("{}", selected))
-            .show_ui(ui, |ui| {
-                for option in [
-                    ActivationOption::Inherit,
-                    ActivationOption::Enable,
-                    ActivationOption::Disable,
-                ] {
-                    ui.selectable_value(&mut selected, option, format!("{}", option));
-                }
-            });
-
-        if before != selected {
-            monitor_config.highlight_focused_workspace = selected.into();
-        }
-    }
-
     fn font_family_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
         let monitor_config = self.config.get_monitor_mut(monitor_id);
         ui.label("Font Family");
@@ -327,48 +310,68 @@ impl SettingsWindowView {
         });
     }
 
-    fn active_indicator_color_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
-        let monitor_config = self.config.get_monitor_mut(monitor_id);
-        ui.label("Active Indicator");
+    fn color_ui(ui: &mut egui::Ui, label: &str, color: &mut Option<String>) {
+        ui.label(label);
         ui.horizontal(|ui| {
-            let colors = &monitor_config.colors;
+            let mut inherit = color.is_none();
+            let mut value = color.clone().unwrap_or_default();
 
-            let mut inherit = colors.active_indicator.is_none();
-            let mut color = colors.active_indicator.clone().unwrap_or_default();
-
-            let text_edit = egui::TextEdit::singleline(&mut color);
+            let text_edit = egui::TextEdit::singleline(&mut value);
             let text_edit = text_edit.hint_text("#FFFFFFFF");
             if ui.add_enabled(!inherit, text_edit).changed() {
-                monitor_config.colors.active_indicator = (!color.is_empty()).then_some(color);
+                *color = (!value.is_empty()).then_some(value);
             }
 
             if ui.checkbox(&mut inherit, "Inherit").changed() {
-                monitor_config.colors.active_indicator =
-                    if inherit { None } else { Some(String::new()) };
+                *color = if inherit { None } else { Some(String::new()) };
             }
         });
     }
 
-    fn busy_indicator_color_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
+    fn workspace_colors_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
         let monitor_config = self.config.get_monitor_mut(monitor_id);
-        ui.label("Busy Indicator");
-        ui.horizontal(|ui| {
-            let colors = &monitor_config.colors;
+        Self::color_ui(ui, "Background", &mut monitor_config.colors.background);
+        ui.end_row();
 
-            let mut inherit = colors.busy_indicator.is_none();
-            let mut color = colors.busy_indicator.clone().unwrap_or_default();
+        Self::color_ui(
+            ui,
+            "Busy Background",
+            &mut monitor_config.colors.busy_background,
+        );
+        ui.end_row();
 
-            let text_edit = egui::TextEdit::singleline(&mut color);
-            let text_edit = text_edit.hint_text("#FFFFFFFF");
-            if ui.add_enabled(!inherit, text_edit).changed() {
-                monitor_config.colors.busy_indicator = (!color.is_empty()).then_some(color);
-            }
+        Self::color_ui(
+            ui,
+            "Active Background",
+            &mut monitor_config.colors.active_background,
+        );
+        ui.end_row();
 
-            if ui.checkbox(&mut inherit, "Inherit").changed() {
-                monitor_config.colors.busy_indicator =
-                    if inherit { None } else { Some(String::new()) };
-            }
-        });
+        Self::color_ui(ui, "Border", &mut monitor_config.colors.border);
+        ui.end_row();
+
+        Self::color_ui(ui, "Busy Border", &mut monitor_config.colors.busy_border);
+        ui.end_row();
+
+        Self::color_ui(
+            ui,
+            "Active Border",
+            &mut monitor_config.colors.active_border,
+        );
+        ui.end_row();
+
+        Self::color_ui(
+            ui,
+            "Active Indicator",
+            &mut monitor_config.colors.active_indicator,
+        );
+        ui.end_row();
+
+        Self::color_ui(
+            ui,
+            "Busy Indicator",
+            &mut monitor_config.colors.busy_indicator,
+        );
     }
 
     fn monitor_settings_ui(&mut self, ui: &mut egui::Ui, monitor_id: &str) {
@@ -393,19 +396,13 @@ impl SettingsWindowView {
         self.hide_empty_workspaces_ui(ui, monitor_id);
         ui.end_row();
 
-        self.highlight_focused_workspace_ui(ui, monitor_id);
-        ui.end_row();
-
         self.font_family_ui(ui, monitor_id);
         ui.end_row();
 
         self.font_weight_ui(ui, monitor_id);
         ui.end_row();
 
-        self.active_indicator_color_ui(ui, monitor_id);
-        ui.end_row();
-
-        self.busy_indicator_color_ui(ui, monitor_id);
+        self.workspace_colors_ui(ui, monitor_id);
         ui.end_row();
     }
 

--- a/src/windows/windows/switcher/host.rs
+++ b/src/windows/windows/switcher/host.rs
@@ -20,6 +20,7 @@ pub unsafe fn create_host(
 ) -> anyhow::Result<HWND> {
     let hinstance = unsafe { GetModuleHandleW(None) }?;
 
+
     let mut rect = RECT::default();
     GetClientRect(taskbar_hwnd, &mut rect)?;
 

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -272,11 +272,7 @@ impl SwitcherWindowView {
 
     /// Applies the desired font to the egui context if it's not already
     /// applied.
-    fn maybe_apply_font(
-        &mut self,
-        ctx: &egui::Context,
-        resolved: &ResolvedMonitorConfig,
-    ) {
+    fn maybe_apply_font(&mut self, ctx: &egui::Context, resolved: &ResolvedMonitorConfig) {
         let font_family = resolved.font_family.as_deref();
         let font_weight = resolved.font_weight;
 
@@ -365,11 +361,7 @@ impl SwitcherWindowView {
     }
 
     /// Main UI elements, workspaces buttons, layout button ...etc
-    fn switcher_ui(
-        &mut self,
-        ui: &mut egui::Ui,
-        resolved: &ResolvedMonitorConfig,
-    ) {
+    fn switcher_ui(&mut self, ui: &mut egui::Ui, resolved: &ResolvedMonitorConfig) {
         ui.style_mut().spacing.item_spacing = egui::vec2(4., 4.);
 
         let hide_empty_workspaces = resolved.hide_empty_workspaces;

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -353,6 +353,7 @@ impl SwitcherWindowView {
             .line_active_color_opt(active_indicator_color)
             .line_busy_color_opt(busy_indicator_color)
             .width_opt(uniform_width)
+            .highlight_focused_opt(Some(resolved.highlight_focused_workspace))
             .text_color_opt(self.forgreound_color);
 
         if ui.add(btn).clicked() {

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -335,6 +335,7 @@ impl SwitcherWindowView {
         workspace: &crate::komorebi::Workspace,
         monitor_config: &crate::config::MonitorConfig,
         config: &Config,
+        uniform_width: Option<f32>,
     ) {
         // Determine active indicator colors,
         // with monitor config taking precedence over global config,
@@ -364,6 +365,7 @@ impl SwitcherWindowView {
             .dark_mode(Some(self.is_system_dark_mode()))
             .line_active_color_opt(active_indicator_color)
             .line_busy_color_opt(busy_indicator_color)
+            .width_opt(uniform_width)
             .text_color_opt(self.forgreound_color);
 
         if ui.add(btn).clicked() {
@@ -387,14 +389,37 @@ impl SwitcherWindowView {
             None => config.hide_empty_workspaces,
         };
 
-        // Draw a button for each workspace
-        for workspace in self.monitor_state.workspaces.iter() {
-            //Skip empty and unfocused workspaces if the setting is enabled
-            if hide_empty_workspaces && workspace.is_empty && !workspace.focused {
-                continue;
-            }
+        let visible_workspaces = self
+            .monitor_state
+            .workspaces
+            .iter()
+            .filter(|workspace| !(hide_empty_workspaces && workspace.is_empty && !workspace.focused))
+            .collect::<Vec<_>>();
 
-            self.workspace_button(ui, workspace, monitor_config, config);
+        let uniform_width = {
+            const MIN_WIDTH: f32 = 28.0;
+            const HORIZONTAL_TEXT_PADDING: f32 = 16.0;
+
+            let max_text_width = visible_workspaces
+                .iter()
+                .map(|workspace| {
+                    ui.painter()
+                        .layout_no_wrap(
+                            workspace.name.clone(),
+                            egui::FontId::default(),
+                            egui::Color32::TRANSPARENT,
+                        )
+                        .rect
+                        .width()
+                })
+                .fold(0.0, f32::max);
+
+            Some((max_text_width + HORIZONTAL_TEXT_PADDING).max(MIN_WIDTH))
+        };
+
+        // Draw a button for each workspace
+        for workspace in visible_workspaces {
+            self.workspace_button(ui, workspace, monitor_config, config, uniform_width);
         }
 
         // Show layout button for focused workspace if the setting is enabled

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -12,7 +12,7 @@ use winit::event_loop::ActiveEventLoop;
 use winit::platform::windows::WindowAttributesExtWindows;
 use winit::window::WindowAttributes;
 
-use crate::config::Config;
+use crate::config::{Config, ResolvedMonitorConfig};
 use crate::komorebi::CycleDirection;
 use crate::windows::app::{App, AppMessage};
 use crate::windows::context_menu::AppContextMenu;
@@ -51,7 +51,10 @@ impl App {
             monitor_config.height,
         ));
 
-        let parent = unsafe { NonZero::new_unchecked(host.0 as _) };
+        let parent = {
+            debug_assert!(!host.is_invalid(), "host window must not be null");
+            unsafe { NonZero::new_unchecked(host.0 as _) }
+        };
         let parent = Win32WindowHandle::new(parent);
         let parent = RawWindowHandle::Win32(parent);
         attrs = unsafe { attrs.with_parent_window(Some(parent)) };
@@ -95,6 +98,7 @@ pub struct SwitcherWindowView {
     accent_light2_color: Option<egui::Color32>,
     accent_color: Option<egui::Color32>,
     forgreound_color: Option<egui::Color32>,
+    dark_mode: Option<bool>,
     prev_bounds: Option<egui::Rect>,
     applied_font: Option<(String, u16)>,
 }
@@ -115,6 +119,7 @@ impl SwitcherWindowView {
             accent_color: None,
             accent_light2_color: None,
             forgreound_color: None,
+            dark_mode: None,
             config,
             preview_config: None,
             prev_bounds: None,
@@ -132,13 +137,15 @@ impl SwitcherWindowView {
 
 /// Getters
 impl SwitcherWindowView {
-    /// Gets the effective config for the switcher, which is the preview config
-    /// if set, or the actual config otherwise.
-    fn effective_config(&self) -> Config {
-        self.preview_config.clone().unwrap_or_else(|| {
-            let config = self.config.read().unwrap();
-            config.clone()
-        })
+    fn resolved_config(&self) -> ResolvedMonitorConfig {
+        if let Some(preview) = &self.preview_config {
+            preview.resolved_monitor_config(&self.monitor_state.id)
+        } else {
+            self.config
+                .read()
+                .unwrap()
+                .resolved_monitor_config(&self.monitor_state.id)
+        }
     }
 
     /// Gets the height of the taskbar.
@@ -150,11 +157,8 @@ impl SwitcherWindowView {
     }
 
     /// Determines if the system is in dark mode.
-    // FIXME: use egui internal dark mode detection
     fn is_system_dark_mode(&self) -> bool {
-        self.forgreound_color
-            .map(|c| c == egui::Color32::WHITE)
-            .unwrap_or(false)
+        self.dark_mode.unwrap_or(false)
     }
 
     /// Gets the accent color to use for the switcher, based on the system
@@ -196,6 +200,14 @@ impl SwitcherWindowView {
         let color = egui::Color32::from_rgb(color.R, color.G, color.B);
         self.forgreound_color.replace(color);
 
+        let dark_mode = windows_registry::CURRENT_USER
+            .open("Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize")
+            .ok()
+            .and_then(|key| key.get_u32("AppsUseLightTheme").ok())
+            .map(|v| v == 0)
+            .unwrap_or(false);
+        self.dark_mode.replace(dark_mode);
+
         Ok(())
     }
 
@@ -205,24 +217,24 @@ impl SwitcherWindowView {
         &mut self,
         rect: egui::Rect,
         ppp: f32,
-        monitor_config: &crate::config::MonitorConfig,
+        resolved: &ResolvedMonitorConfig,
     ) -> anyhow::Result<()> {
         // Scale by pixels per point
         let rect = rect * ppp;
 
-        let x = monitor_config.x;
-        let y = monitor_config.y;
+        let x = resolved.x;
+        let y = resolved.y;
 
-        let height = if monitor_config.auto_height {
+        let height = if resolved.auto_height {
             self.taskbar_height()?
         } else {
-            monitor_config.height
+            resolved.height
         };
 
-        let width = if monitor_config.auto_width {
+        let width = if resolved.auto_width {
             rect.width() as i32
         } else {
-            monitor_config.width
+            resolved.width
         };
 
         let current_bounds = egui::Rect::from_min_size(
@@ -247,7 +259,7 @@ impl SwitcherWindowView {
             }?;
 
             // Store auto size if needed
-            if monitor_config.auto_width || monitor_config.auto_height {
+            if resolved.auto_width || resolved.auto_height {
                 let _ = registry::store_auto_size(&self.monitor_state.id, width, height);
             }
 
@@ -263,17 +275,10 @@ impl SwitcherWindowView {
     fn maybe_apply_font(
         &mut self,
         ctx: &egui::Context,
-        config: &Config,
-        monitor_config: &crate::config::MonitorConfig,
+        resolved: &ResolvedMonitorConfig,
     ) {
-        let font_family = monitor_config
-            .font_family
-            .as_deref()
-            .or(config.font_family.as_deref());
-        let font_weight = monitor_config
-            .font_weight
-            .or(config.font_weight)
-            .unwrap_or(400);
+        let font_family = resolved.font_family.as_deref();
+        let font_weight = resolved.font_weight;
 
         // Skip if the desired font is already applied
         let desired = font_family.map(|family| (family.to_string(), font_weight));
@@ -333,33 +338,19 @@ impl SwitcherWindowView {
         &self,
         ui: &mut egui::Ui,
         workspace: &crate::komorebi::Workspace,
-        monitor_config: &crate::config::MonitorConfig,
-        config: &Config,
+        resolved: &ResolvedMonitorConfig,
         uniform_width: Option<f32>,
     ) {
-        // Determine active indicator colors,
-        // with monitor config taking precedence over global config,
-        // and falling back to accent color if not specified.
-        let active_indicator_color = match monitor_config.colors.active_indicator {
-            Some(ref c) => egui_color_from_color(c),
-            None => config
-                .colors
-                .active_indicator
-                .as_ref()
-                .and_then(|c| egui_color_from_color(c)),
-        };
-        let active_indicator_color = active_indicator_color.or_else(|| self.accent_color());
+        let active_indicator_color = resolved
+            .active_indicator
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c))
+            .or_else(|| self.accent_color());
 
-        // Determine busy indicator color,
-        // with monitor config taking precedence over global config.
-        let busy_indicator_color = match monitor_config.colors.busy_indicator {
-            Some(ref c) => egui_color_from_color(c),
-            None => config
-                .colors
-                .busy_indicator
-                .as_ref()
-                .and_then(|c| egui_color_from_color(c)),
-        };
+        let busy_indicator_color = resolved
+            .busy_indicator
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c));
 
         let btn = WorkspaceButton::new(workspace)
             .dark_mode(Some(self.is_system_dark_mode()))
@@ -377,17 +368,11 @@ impl SwitcherWindowView {
     fn switcher_ui(
         &mut self,
         ui: &mut egui::Ui,
-        config: &Config,
-        monitor_config: &crate::config::MonitorConfig,
+        resolved: &ResolvedMonitorConfig,
     ) {
-        // Set spacing between buttons
         ui.style_mut().spacing.item_spacing = egui::vec2(4., 4.);
 
-        // Determine whether to show or hide empty workspaces
-        let hide_empty_workspaces = match monitor_config.hide_empty_workspaces {
-            Some(hide) => hide,
-            None => config.hide_empty_workspaces,
-        };
+        let hide_empty_workspaces = resolved.hide_empty_workspaces;
 
         let visible_workspaces = self
             .monitor_state
@@ -419,14 +404,10 @@ impl SwitcherWindowView {
 
         // Draw a button for each workspace
         for workspace in visible_workspaces {
-            self.workspace_button(ui, workspace, monitor_config, config, uniform_width);
+            self.workspace_button(ui, workspace, resolved, uniform_width);
         }
 
-        // Show layout button for focused workspace if the setting is enabled
-        let show_layout_button = match monitor_config.show_layout_button {
-            Some(show) => show,
-            None => config.show_layout_button,
-        };
+        let show_layout_button = resolved.show_layout_button;
         if show_layout_button {
             if let Some(focused_ws) = self.monitor_state.focused_workspace() {
                 ui.add(egui::Label::new("|"));
@@ -441,8 +422,7 @@ impl SwitcherWindowView {
     fn switcher_panel(
         &mut self,
         ctx: &egui::Context,
-        config: &Config,
-        monitor_config: &crate::config::MonitorConfig,
+        resolved: &ResolvedMonitorConfig,
     ) -> egui::InnerResponse<egui::Rect> {
         // Set transparent panel visual for the switcher.
         let visuals = egui::Visuals {
@@ -458,7 +438,7 @@ impl SwitcherWindowView {
         let total_margin = frame.total_margin();
         egui::CentralPanel::default().frame(frame).show(ctx, |ui| {
             let response = ui.horizontal_centered(|ui| {
-                self.switcher_ui(ui, config, monitor_config);
+                self.switcher_ui(ui, resolved);
                 ui.min_rect()
             });
 
@@ -505,24 +485,18 @@ impl EguiView for SwitcherWindowView {
 
     // Main render loop
     fn update(&mut self, ctx: &egui::Context) {
-        // Show context menu on right click
         if ctx.input(|i| i.pointer.button_pressed(egui::PointerButton::Secondary)) {
             self.show_context_menu();
         }
 
-        // Load effective config.
-        let config = self.effective_config();
-        let monitor_config = config.get_monitor(&self.monitor_state.id);
+        let resolved = self.resolved_config();
 
-        // Apply font
-        self.maybe_apply_font(ctx, &config, &monitor_config);
+        self.maybe_apply_font(ctx, &resolved);
 
-        // Draw ui
-        let response = self.switcher_panel(ctx, &config, &monitor_config);
+        let response = self.switcher_panel(ctx, &resolved);
 
-        // Resize host to match the content rect.
         let ppp = ctx.pixels_per_point();
-        if let Err(e) = self.resize_host_to_rect(response.inner, ppp, &monitor_config) {
+        if let Err(e) = self.resize_host_to_rect(response.inner, ppp, &resolved) {
             tracing::error!("Failed to resize host to rect: {e}");
         }
     }

--- a/src/windows/windows/switcher/mod.rs
+++ b/src/windows/windows/switcher/mod.rs
@@ -347,13 +347,42 @@ impl SwitcherWindowView {
             .busy_indicator
             .as_ref()
             .and_then(|c| egui_color_from_color(c));
+        let background_color = resolved
+            .background
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c));
+        let busy_background_color = resolved
+            .busy_background
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c));
+        let active_background_color = resolved
+            .active_background
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c));
+        let border_color = resolved
+            .border
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c));
+        let busy_border_color = resolved
+            .busy_border
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c));
+        let active_border_color = resolved
+            .active_border
+            .as_ref()
+            .and_then(|c| egui_color_from_color(c));
 
         let btn = WorkspaceButton::new(workspace)
             .dark_mode(Some(self.is_system_dark_mode()))
             .line_active_color_opt(active_indicator_color)
             .line_busy_color_opt(busy_indicator_color)
+            .background_color_opt(background_color)
+            .busy_background_color_opt(busy_background_color)
+            .active_background_color_opt(active_background_color)
+            .border_color_opt(border_color)
+            .busy_border_color_opt(busy_border_color)
+            .active_border_color_opt(active_border_color)
             .width_opt(uniform_width)
-            .highlight_focused_opt(Some(resolved.highlight_focused_workspace))
             .text_color_opt(self.forgreound_color);
 
         if ui.add(btn).clicked() {
@@ -371,7 +400,9 @@ impl SwitcherWindowView {
             .monitor_state
             .workspaces
             .iter()
-            .filter(|workspace| !(hide_empty_workspaces && workspace.is_empty && !workspace.focused))
+            .filter(|workspace| {
+                !(hide_empty_workspaces && workspace.is_empty && !workspace.focused)
+            })
             .collect::<Vec<_>>();
 
         let uniform_width = {


### PR DESCRIPTION
- Added highlight_focused_workspace to Config (global, default \true for backward-compatible behavior) and MonitorConfig (per-monitor Option<bool> override)
- Added highlight_focused_opt() builder to Windows WorkspaceButton widget and highlight_focused parameter to macOS WorkspaceButton
- Settings UI: global checkbox + per-monitor Inherit/Enable/Disable combo
- When enabled: focused workspace button shows subtle background highlight; when disabled: only the indicator bar (and hover) provides visual feedback
> Depends on #<config_pr_number> (includes config resolution refactoring)
