### PR TITLE
fix: dead code, renderer panic, and Win32 class re-registration

### DIFF
--- a/src/windows/app.rs
+++ b/src/windows/app.rs
@@ -211,20 +211,25 @@ impl ApplicationHandler<AppMessage> for App {
         window_id: WindowId,
         event: WindowEvent,
     ) {
-        if event == WindowEvent::Destroyed {
-            tracing::info!("Window {window_id:?} destroyed");
-            self.windows.remove(&window_id);
-            return;
-        }
+        match event {
+            WindowEvent::CloseRequested => {
+                tracing::info!("Window {window_id:?} close requested");
+                self.windows.remove(&window_id);
 
-        if matches!(event, WindowEvent::CloseRequested | WindowEvent::Destroyed) {
-            tracing::info!("Closing window {window_id:?}");
-            self.windows.remove(&window_id);
-
-            if self.windows.is_empty() {
-                tracing::info!("Exiting event loop");
-                event_loop.exit();
+                if self.windows.is_empty() {
+                    tracing::info!("Exiting event loop");
+                    event_loop.exit();
+                }
+                return;
             }
+
+            WindowEvent::Destroyed => {
+                tracing::info!("Window {window_id:?} destroyed");
+                self.windows.remove(&window_id);
+                return;
+            }
+
+            _ => {}
         }
 
         let Some(window) = self.windows.get_mut(&window_id) else {

--- a/src/windows/egui_glue/egui_renderer.rs
+++ b/src/windows/egui_glue/egui_renderer.rs
@@ -68,8 +68,14 @@ impl EguiRenderer {
         window_surface_view: &wgpu::TextureView,
         screen_descriptor: egui_wgpu::ScreenDescriptor,
     ) {
+        debug_assert!(
+            self.frame_started,
+            "begin_frame must be called before end_frame_and_draw can be called!"
+        );
+
         if !self.frame_started {
-            panic!("begin_frame must be called before end_frame_and_draw can be called!");
+            tracing::error!("end_frame_and_draw called without begin_frame");
+            return;
         }
 
         let full_output = self.state.egui_ctx().end_pass();

--- a/src/windows/message_window.rs
+++ b/src/windows/message_window.rs
@@ -1,4 +1,4 @@
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use windows::core::*;
 use windows::Win32::Foundation::*;
@@ -16,6 +16,8 @@ const MESSAGE_WINDOW_CLASSNAME: PCWSTR = w!("komorebi-switcher::message-window")
 static WM_TASKBARCREATED: LazyLock<u32> =
     LazyLock::new(|| unsafe { RegisterWindowMessageA(s!("TaskbarCreated")) });
 
+static MESSAGE_CLASS_REGISTERED: OnceLock<()> = OnceLock::new();
+
 struct WndProcUserData {
     proxy: EventLoopProxy<AppMessage>,
 }
@@ -29,14 +31,20 @@ impl WndProcUserData {
 pub unsafe fn create(proxy: EventLoopProxy<AppMessage>) -> anyhow::Result<HWND> {
     let hinstance = GetModuleHandleW(None)?;
 
-    let wc = WNDCLASSW {
-        hInstance: hinstance.into(),
-        lpszClassName: MESSAGE_WINDOW_CLASSNAME,
-        lpfnWndProc: Some(wndproc_message_window),
-        ..Default::default()
-    };
+    MESSAGE_CLASS_REGISTERED.get_or_init(|| {
+        let wc = WNDCLASSW {
+            hInstance: hinstance.into(),
+            lpszClassName: MESSAGE_WINDOW_CLASSNAME,
+            lpfnWndProc: Some(wndproc_message_window),
+            ..Default::default()
+        };
 
-    RegisterClassW(&wc);
+        assert_ne!(
+            unsafe { RegisterClassW(&wc) },
+            0,
+            "Failed to register message window class"
+        );
+    });
 
     let userdata = WndProcUserData { proxy };
 

--- a/src/windows/windows/switcher/host.rs
+++ b/src/windows/windows/switcher/host.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use windows::core::*;
 use windows::Win32::Foundation::*;
 use windows::Win32::System::LibraryLoader::*;
@@ -13,6 +15,8 @@ const HOST_CLASSNAME: PCWSTR = w!("komorebi-switcher-debug::host");
 #[cfg(not(debug_assertions))]
 const HOST_CLASSNAME: PCWSTR = w!("komorebi-switcher::host");
 
+static HOST_CLASS_REGISTERED: OnceLock<()> = OnceLock::new();
+
 pub unsafe fn create_host(
     taskbar_hwnd: HWND,
     proxy: EventLoopProxy<AppMessage>,
@@ -20,20 +24,22 @@ pub unsafe fn create_host(
 ) -> anyhow::Result<HWND> {
     let hinstance = unsafe { GetModuleHandleW(None) }?;
 
-    let mut rect = RECT::default();
-    GetClientRect(taskbar_hwnd, &mut rect)?;
+    HOST_CLASS_REGISTERED.get_or_init(|| {
+        let wc = WNDCLASSW {
+            hInstance: hinstance.into(),
+            lpszClassName: HOST_CLASSNAME,
+            style: CS_HREDRAW | CS_VREDRAW,
+            lpfnWndProc: Some(wndproc_host),
+            ..Default::default()
+        };
 
-    let wc = WNDCLASSW {
-        hInstance: hinstance.into(),
-        lpszClassName: HOST_CLASSNAME,
-        style: CS_HREDRAW | CS_VREDRAW,
-        lpfnWndProc: Some(wndproc_host),
-        ..Default::default()
-    };
-
-    RegisterClassW(&wc);
+        assert_ne!(unsafe { RegisterClassW(&wc) }, 0, "Failed to register host window class");
+    });
 
     let userdata = WndProcUserData { proxy };
+
+    let mut rect = RECT::default();
+    GetClientRect(taskbar_hwnd, &mut rect)?;
 
     let height = if monitor_config.auto_height {
         rect.bottom - rect.top


### PR DESCRIPTION
- RegisterClassW guarded with OnceLock to prevent repeated class registration per monitor
- Renderer panic! replaced with debug_assert! + graceful return for release builds
- Merged duplicate CloseRequested/Destroyed handler blocks, eliminated dead code path
